### PR TITLE
BF: circular import of injector and duecredit

### DIFF
--- a/duecredit/__init__.py
+++ b/duecredit/__init__.py
@@ -50,7 +50,7 @@ def _get_active_due():
 
     # Deal with injector
     from .injections import DueCreditInjector
-    injector = DueCreditInjector()
+    injector = DueCreditInjector(due)
     injector.activate()
     #injector.deactivate()
     return due

--- a/duecredit/__init__.py
+++ b/duecredit/__init__.py
@@ -50,7 +50,7 @@ def _get_active_due():
 
     # Deal with injector
     from .injections import DueCreditInjector
-    injector = DueCreditInjector(due)
+    injector = DueCreditInjector(collector=due)
     injector.activate()
     #injector.deactivate()
     return due

--- a/duecredit/injections/injector.py
+++ b/duecredit/injections/injector.py
@@ -61,12 +61,7 @@ class DueCreditInjector(object):
     """
     def __init__(self, collector=None):
         if collector is None:
-            if os.path.exists(DUECREDIT_FILE):
-                from ..io import load_due
-                due = load_due(DUECREDIT_FILE)
-            else:
-                from ..collector import DueCreditCollector
-                due = DueCreditCollector()
+            from duecredit import due
             collector = due
         self._collector = collector
         self._delayed_entries = {}

--- a/duecredit/injections/injector.py
+++ b/duecredit/injections/injector.py
@@ -11,6 +11,8 @@
 
 __docformat__ = 'restructuredtext'
 
+from ..config import DUECREDIT_FILE
+import os
 from os.path import basename, join as pathjoin, dirname
 from glob import glob
 import sys
@@ -59,7 +61,12 @@ class DueCreditInjector(object):
     """
     def __init__(self, collector=None):
         if collector is None:
-            from duecredit import due
+            if os.path.exists(DUECREDIT_FILE):
+                from ..io import load_due
+                due = load_due(DUECREDIT_FILE)
+            else:
+                from ..collector import DueCreditCollector
+                due = DueCreditCollector()
             collector = due
         self._collector = collector
         self._delayed_entries = {}

--- a/duecredit/injections/injector.py
+++ b/duecredit/injections/injector.py
@@ -11,8 +11,6 @@
 
 __docformat__ = 'restructuredtext'
 
-from ..config import DUECREDIT_FILE
-import os
 from os.path import basename, join as pathjoin, dirname
 from glob import glob
 import sys


### PR DESCRIPTION
Before at `import duecredit` it would fail because in `__init__.py` it calls the injector, and the injector called `from duecredit import due` but at that point wasn't existing yet.