### PR TITLE
BF: give correct ref numbers for citations

### DIFF
--- a/duecredit/io.py
+++ b/duecredit/io.py
@@ -112,17 +112,19 @@ class TextOutput(object):  # TODO some parent class to do what...?
         # different renderings given the model -- text, rest, md, tex+latex, whatever
         self.fd.write('DueCredit Report:\n')
 
-        refnr = 1
+        refnr = 0
         citations_ordered = []
 
         for package, (package_citations, obj_citations) in iteritems(cited_packages):
             # package level citation
             versions = sorted(map(str, set(str(r.version) for r in package_citations)))
-            refnr = len(citations_ordered) + 1
+            refnr += 1
             self.fd.write('- {0} (v {1}) [{2}]\n'.format(
                 package,
                 ', '.join(versions),
                 ', '.join(str(x) for x in range(refnr, refnr+len(package_citations)))))
+            # update refnr in case there are multiple citations for the package
+            refnr += len(package_citations) - 1
             citations_ordered.extend(package_citations)
 
 
@@ -132,12 +134,12 @@ class TextOutput(object):  # TODO some parent class to do what...?
                 # description so must be groupped accordingly. For now just simply listing them
                 # all separately
                 for citation in citations:
-                    refnr = len(citations_ordered) + 1
+                    refnr += 1
                     self.fd.write('  - {0} ({1}) [{2}]\n'.format(
                         citation.path,
                         citation.description,
                         refnr))
-                    citations_ordered.extend(citations)
+                citations_ordered.extend(citations)
 
         # Let's collect some stats now (before it was misleading since multiple citations
         # could have been for the same package or object)


### PR DESCRIPTION
Fixes #23 

Now the output is:

```
DueCredit Report:
- numpy (v 1.9.2) [1]
- mvpa2 (v 2.4) [2]
  - mvpa2.featsel.rfe:_train (Recursive feature elimination procedure) [3]
  - mvpa2.algorithms.group_clusterthr:_train (Statistical assessment of (searchlight) MVPA results) [4]
  - mvpa2.clfs.transerror:_call (Bayesian hypothesis testing) [5]

2 modules cited
2 functions cited

References
----------

[1] Van Der Walt, S., Colbert, S.C. & Varoquaux, G., 2011. The NumPy array: a structure for efficient numerical computation. Computing in Science & Engineering, 13(2), pp.22–30.
[2] Hanke, M. et al., 2009. PyMVPA: a Python Toolbox for Multivariate Pattern Analysis of fMRI Data. Neuroinformatics, 7(1), pp.37–53.
[3] Guyon, I. et al., 2002. Gene Selection for Cancer Classification using Support Vector Machines. Machine Learning, 46, pp.389–422.
[4] Stelzer, J., Chen, Y. & Turner, R., 2013. Statistical inference and multiple testing correction in classification-based multi-voxel pattern analysis (MVPA): Random permutations and cluster size control. NeuroImage, 65, pp.69–82.
[5] Olivetti, E., Veeramachaneni, S. & Nowakowska, E., 2012. Bayesian hypothesis testing for pattern discrimination in brain decoding. Pattern Recognition, 45(6), pp.2075–2084.

```