### PR TITLE
TST: check that cross-referencing works (failing atm)

### DIFF
--- a/duecredit/tests/test_io.py
+++ b/duecredit/tests/test_io.py
@@ -133,8 +133,8 @@ def test_text_output_dump_formatting():
         @due.dcite(BibTeX(samples_bibtex[4]), description='solution to life',
                    path='myothermodule:myotherfunction')
         # XXX: atm cross-referencing doesn't work
-        # @due.dcite(BibTeX(_sample_bibtex2), description='solution to life',
-        #           path='myothermodule:myotherfunction')
+        @due.dcite(BibTeX(_sample_bibtex2), description='solution to life',
+                   path='myothermodule:myotherfunction')
         def myotherfunction(arg42):
             pass
 
@@ -159,8 +159,9 @@ def test_text_output_dump_formatting():
             reference_numbers.append(match_reference.group())
             references.append(line.replace(match_reference.group(), ""))
 
-    assert_equal(citation_numbers, reference_numbers)
-    assert_equal(len(set(references)), len(citation_numbers))
+    assert_equal(set(citation_numbers), set(reference_numbers))
+    assert_equal(len(set(references)), len(set(citation_numbers)))
+    assert_equal(len(citation_numbers), 8)
     # verify that we have returned to previous state of filters
     import warnings
     assert_true(('ignore', None, UserWarning, None, 0) not in warnings.filters)


### PR DESCRIPTION
Related to #30 
I admit this is not the most robust test, but it still checks for cross-ref in this case.

The output of the test is:

```
DueCredit Report:
- mymodule (v 0.0.16) [1]
  - mymodule:myfunction (solution to life) [2]
- myothermodule (v 0.0.666) [3]
  - myothermodule:myotherfunction (solution to life) [4]
  - myothermodule:myotherfunction (solution to life) [5]
  - myothermodule:myotherfunction (solution to life) [6]
  - myothermodule:myotherfunction (solution to life) [7]

2 modules cited
2 functions cited

References
----------

[1] Halchenko, Y.O. & Hanke, M., 2012. Open is not enough. Let's take the next step: An integrated, community-driven
    computing platform for neuroscience. Frontiers in Neuroinformatics, 6(22).
[2] Atkins, J.H. & Gershell, L.J., 2002. title. My Fancy. Journ., 666(3009).
[3] vbcauf, . nmgc ., 679AD. 3hCt9sA ING8bUzrielg. 3V6sHtdzN1 Zu07LnQTS.
[4] saeizm, . ofvn ., 7082. mhZ8tPqMRCHLxbSz92l1. Uoq0HrPXbQu5hF4ASeDf.
[5] vosbai, . gonp ., 5637. 47SlmH29RoQVMxFPisgX. Hz94gbIuSORd1p5oxs63.
[6] fecbia, . zbap ., 6230.  LaQPzCbR73D1nFM5Spq.  qvDSfTMepbxAPsn5o2C.
[7] htogix, . gefa ., 3197. s92Bl6vnVPStaAfRQuo4. QIEtzeRMrOAg TsqmlNf.
```

but it should be

```
DueCredit Report:
- mymodule (v 0.0.16) [1]
  - mymodule:myfunction (solution to life) [2]
- myothermodule (v 0.0.666) [3]
  - myothermodule:myotherfunction (solution to life) [2]
  - myothermodule:myotherfunction (solution to life) [4]
  - myothermodule:myotherfunction (solution to life) [5]
  - myothermodule:myotherfunction (solution to life) [6]
  - myothermodule:myotherfunction (solution to life) [7]

2 modules cited
2 functions cited

References
----------

[1] Halchenko, Y.O. & Hanke, M., 2012. Open is not enough. Let's take the next step: An integrated, community-driven
    computing platform for neuroscience. Frontiers in Neuroinformatics, 6(22).
[2] Atkins, J.H. & Gershell, L.J., 2002. title. My Fancy. Journ., 666(3009).
[3] vbcauf, . nmgc ., 679AD. 3hCt9sA ING8bUzrielg. 3V6sHtdzN1 Zu07LnQTS.
[4] saeizm, . ofvn ., 7082. mhZ8tPqMRCHLxbSz92l1. Uoq0HrPXbQu5hF4ASeDf.
[5] vosbai, . gonp ., 5637. 47SlmH29RoQVMxFPisgX. Hz94gbIuSORd1p5oxs63.
[6] fecbia, . zbap ., 6230.  LaQPzCbR73D1nFM5Spq.  qvDSfTMepbxAPsn5o2C.
[7] htogix, . gefa ., 3197. s92Bl6vnVPStaAfRQuo4. QIEtzeRMrOAg TsqmlNf.
```