### PR TITLE
Few tune ups to injection and more to its testing

### DIFF
--- a/duecredit/injections/injector.py
+++ b/duecredit/injections/injector.py
@@ -242,11 +242,18 @@ class DueCreditInjector(object):
                     # so let's assume that they were all processed already
                     self._processed_modules = set(sys.modules)
 
+                mod = None
                 try:
                     self.__import_level += 1
                     # TODO: safe-guard all our logic so
                     # if anything goes wrong post-import -- we still return imported module
-                    mod = self._orig_import(name, *args, **kwargs)
+                    if self._orig_import:
+                        mod = self._orig_import(name, *args, **kwargs)
+                    else:
+                        lgr.error("For some reason self._orig_import is None"
+                                  ". Importing using stock importer to mitigate")
+                        mod = _very_orig_import(name, *args, **kwargs)
+
                     self._handle_fresh_imports(name, import_level_prefix, level)
                 finally:
                     self.__import_level -= 1

--- a/duecredit/tests/test_injections.py
+++ b/duecredit/tests/test_injections.py
@@ -177,10 +177,9 @@ def test_injector_del():
         assert_false(inj._orig_import is None)
         del inj   # delete active but not used
         inj = None
+        __builtin__.__import__ = None # We need to do that since otherwise gc will not pick up inj
         gc.collect()  # To cause __del__
-        if PY2:
-            # TODO: for some reason above mambo doesn't cause __del__ being invoked :-/ figure it out
-            assert_true(__builtin__.__import__ is orig__import__)
+        assert_true(__builtin__.__import__ is orig__import__)
         import abc   # and new imports work just fine
     finally:
         __builtin__.__import__ = orig__import__

--- a/duecredit/tests/test_injections.py
+++ b/duecredit/tests/test_injections.py
@@ -43,7 +43,8 @@ class TestActiveInjector(object):
         self.injector.activate(retrospect=False)  # numpy might be already loaded...
 
     def teardown(self):
-        assert_false(__builtin__.__import__ is _orig__import__)
+        # gc might not pick up inj after some tests complete
+        # so we will always deactivate explicitly
         self.injector.deactivate()
         assert_true(__builtin__.__import__ is _orig__import__)
         self._cleanup_modules()


### PR DESCRIPTION
primarily driven by difficulty to rely on __del__ being invoked. gc might delay picking up all the objects for various reasons (e.g. binding to decorated __import)