### PR TITLE
RF: cite-on-import -> cite-module  since we might be dealing with other languages etc

### DIFF
--- a/duecredit/collector.py
+++ b/duecredit/collector.py
@@ -53,7 +53,7 @@ class Citation(object):
              the method
           - "edu" references to tutorials, textbooks and other materials useful to learn
             more
-          - "cite-on-use" for a module citation would make that module citeable even
+          - "cite-module" for a module citation would make that module citeable even
             without internal duecredited functionality invoked.  Should be used only for
             core packages whenever it is reasonable to assume that its import constitute
             its use (e.g. numpy)

--- a/duecredit/collector.py
+++ b/duecredit/collector.py
@@ -27,7 +27,8 @@ lgr = logging.getLogger('duecredit.collector')
 class Citation(object):
     """Encapsulates citations and information on their use"""
 
-    def __init__(self, entry, description=None, path=None, version=None, tags=['implementation']):
+    def __init__(self, entry, description=None, path=None, version=None,
+                 cite_module=False, tags=['implementation']):
         """Cite a reference
 
         Parameters
@@ -42,6 +43,11 @@ class Citation(object):
           path from the path within the module.
         version: str or tuple, version
           Version of the beast (e.g. of the module) where applicable
+        cite_module: bool, optional
+          If it is a module citation, setting it to True would make that module citeable
+          even without internal duecredited functionality invoked.  Should be used only for
+          core packages whenever it is reasonable to assume that its import constitute
+          its use (e.g. numpy)
         tags: list of str, optional
           Add tags for the reference for this method.  Some tags have associated
           semantics in duecredit, e.g.
@@ -53,10 +59,6 @@ class Citation(object):
              the method
           - "edu" references to tutorials, textbooks and other materials useful to learn
             more
-          - "cite-module" for a module citation would make that module citeable even
-            without internal duecredited functionality invoked.  Should be used only for
-            core packages whenever it is reasonable to assume that its import constitute
-            its use (e.g. numpy)
           - "donate" should be commonly used with Url entries to point to the websites
             describing how to contribute some funds to the referenced project
         """
@@ -64,6 +66,7 @@ class Citation(object):
         self._description = description
         # We might want extract all the relevant functionality into a separate class
         self._path = path
+        self._cite_module = cite_module
         self.count = 0
         self.tags = tags or []
         self.version = version
@@ -74,6 +77,8 @@ class Citation(object):
             args.append("description={0}".format(repr(self._description)))
         if self._path:
             args.append("path={0}".format(repr(self._path)))
+        if self._cite_module:
+            args.append("cite_module={0}".format(repr(self._cite_module)))
 
         if args:
             args = ", ".join(args)
@@ -84,6 +89,10 @@ class Citation(object):
     @property
     def path(self):
         return self._path
+
+    @property
+    def cite_module(self):
+        return self._cite_module
 
     @path.setter
     def path(self, path):
@@ -321,6 +330,11 @@ class DueCreditCollector(object):
                 # TODO: we indeed need to separate path logic outside
                 modname = path.split(':', 1)[0]
 
+            # if decorated function was invoked, it means that we need
+            # to cite that even if it is a module. But do not override
+            # value if user explicitely stated
+            if 'cite_module' not in kwargs:
+                kwargs['cite_module'] = True
 
             # TODO: might make use of inspect.getmro
             # see e.g.

--- a/duecredit/collector.py
+++ b/duecredit/collector.py
@@ -53,7 +53,7 @@ class Citation(object):
              the method
           - "edu" references to tutorials, textbooks and other materials useful to learn
             more
-          - "cite-on-import" for a module citation would make that module citeable even
+          - "cite-on-use" for a module citation would make that module citeable even
             without internal duecredited functionality invoked.  Should be used only for
             core packages whenever it is reasonable to assume that its import constitute
             its use (e.g. numpy)

--- a/duecredit/injections/mod_numpy.py
+++ b/duecredit/injections/mod_numpy.py
@@ -30,5 +30,6 @@ def inject(injector):
         publisher={AIP Publishing}
         }
     """),
-    tags=['reference', 'cite-module'],
+    tags=['reference'],
+    cite_module=True,
     description="Scientific tools library")

--- a/duecredit/injections/mod_numpy.py
+++ b/duecredit/injections/mod_numpy.py
@@ -30,5 +30,5 @@ def inject(injector):
         publisher={AIP Publishing}
         }
     """),
-    tags=['reference', 'cite-on-use'],
+    tags=['reference', 'cite-module'],
     description="Scientific tools library")

--- a/duecredit/injections/mod_numpy.py
+++ b/duecredit/injections/mod_numpy.py
@@ -30,5 +30,5 @@ def inject(injector):
         publisher={AIP Publishing}
         }
     """),
-    tags=['reference', 'cite-on-import'],
+    tags=['reference', 'cite-on-use'],
     description="Scientific tools library")

--- a/duecredit/io.py
+++ b/duecredit/io.py
@@ -100,9 +100,9 @@ class TextOutput(object):  # TODO some parent class to do what...?
         # TODO: theoretically should be done before pruning based on tags so we still
         # catch those which were used anyhow
         for package, (package_citations, obj_citations) in list(iteritems(cited_packages)): # operate on a copy
-            # check if any citation is tagged as 'cite-on-import', so we
+            # check if any citation is tagged as 'cite-on-use', so we
             # always cite if it was imported
-            if any('cite-on-import' in c.tags for c in package_citations):
+            if any('cite-on-use' in c.tags for c in package_citations):
                 continue
             if not obj_citations:
                 cited_packages.pop(package)

--- a/duecredit/io.py
+++ b/duecredit/io.py
@@ -100,9 +100,9 @@ class TextOutput(object):  # TODO some parent class to do what...?
         # TODO: theoretically should be done before pruning based on tags so we still
         # catch those which were used anyhow
         for package, (package_citations, obj_citations) in list(iteritems(cited_packages)): # operate on a copy
-            # check if any citation is tagged as 'cite-on-use', so we
+            # check if any citation is tagged as 'cite-module', so we
             # always cite if it was imported
-            if any('cite-on-use' in c.tags for c in package_citations):
+            if any('cite-module' in c.tags for c in package_citations):
                 continue
             if not obj_citations:
                 cited_packages.pop(package)

--- a/duecredit/io.py
+++ b/duecredit/io.py
@@ -100,9 +100,9 @@ class TextOutput(object):  # TODO some parent class to do what...?
         # TODO: theoretically should be done before pruning based on tags so we still
         # catch those which were used anyhow
         for package, (package_citations, obj_citations) in list(iteritems(cited_packages)): # operate on a copy
-            # check if any citation is tagged as 'cite-module', so we
+            # check if any module citation is "forced", so we
             # always cite if it was imported
-            if any('cite-module' in c.tags for c in package_citations):
+            if any(c.cite_module for c in package_citations):
                 continue
             if not obj_citations:
                 cited_packages.pop(package)

--- a/duecredit/tests/test_collector.py
+++ b/duecredit/tests/test_collector.py
@@ -113,6 +113,7 @@ def test_dcite_method():
                 assert_equal(arg1, "magical")
                 assert_equal(kwarg2, 1)
                 return "load"
+
         if active:
             assert_equal(due.citations, {})
             assert_equal(len(due._entries), 1)
@@ -138,6 +139,29 @@ def test_dcite_method():
             assert_equal(citation.count, 2)
             # TODO: we should actually get path/counts pairs so here
             # it is already a different path
+
+            # And we explicitly stated that module need to be cited
+            assert_true(citation.cite_module)
+
+
+        class SomeClass2(object):
+            @due.dcite("XXX0", path="some.module.without.method")
+            def method2(self, arg1, kwarg2="blah"):
+                assert_equal(arg1, "magical")
+                return "load"
+
+        # and a method pointing to the module
+        instance2 = SomeClass()
+
+        yield _test_dcite_basic, due, instance2.method
+        if active:
+            assert_equal(len(due.citations), 1)
+            assert_equal(len(due._entries), 1) # the same entry
+            assert_equal(citation.count, 3)
+            # TODO: we should actually get path/counts pairs so here
+            # it is already a different path
+            # And we still explicitly stated that module need to be cited
+            assert_true(citation.cite_module)
 
 def _test_args_match_conditions(conds):
     args_match_conditions = DueCreditCollector._args_match_conditions


### PR DESCRIPTION
or might be just referencing a library/package while decorating a method,
so pretty much that citation would only trigger upon use, BUT because it is
a citation for a package -- it would not trigger unless explicitly tagged.
So we pretty much might like to add that tag withing dcite since it guarantees
that function gets called/citation must be in place (TODO: think more about it)

May be you see a better name for this tag @mvdoc ?