### PR TITLE
REF: text output, divide "model" from "view"

### DIFF
--- a/duecredit/collector.py
+++ b/duecredit/collector.py
@@ -73,6 +73,7 @@ class Citation(object):
         self._cite_module = cite_module
         self.tags = tags or []
         self.version = version
+        self.count = 0
 
     def __repr__(self):
         args = [repr(self._entry)]
@@ -237,9 +238,13 @@ class DueCreditCollector(object):
         else:
             entry_ = self._entries[entry]
 
-        citation = Citation(entry_, **kwargs)
-        # update entry count
-        entry_.count += 1
+        entry_key = entry_.get_key()
+        if (path, entry_key) not in self.citations:
+           self.citations[(path, entry_key)]  = Citation(entry_, **kwargs)
+        citation = self.citations[(path, entry_key)]
+        # update citation count
+        citation.count += 1
+
         # TODO: theoretically version shouldn't differ if we don't preload previous results
         if not citation.version:
             version = kwargs.get('version', None)
@@ -260,8 +265,6 @@ class DueCreditCollector(object):
                 #                 and not citation.version:
                 version = external_versions[package]
             citation.version = version
-
-        self.citations[citation.key] = citation
 
         return citation
 

--- a/duecredit/collector.py
+++ b/duecredit/collector.py
@@ -157,6 +157,10 @@ class Citation(object):
         else:
             return entry.path.startswith(self.path + '.')
 
+    @property
+    def key(self):
+        return CitationKey(self.path, self.entry.get_key())
+
 
 class DueCreditCollector(object):
     """Collect the references
@@ -232,7 +236,6 @@ class DueCreditCollector(object):
             entry_ = self._entries[entry.get_key()]
         else:
             entry_ = self._entries[entry]
-        entry_key = entry_.get_key()
 
         citation = Citation(entry_, **kwargs)
         # update entry count
@@ -258,7 +261,7 @@ class DueCreditCollector(object):
                 version = external_versions[package]
             citation.version = version
 
-        self.citations[CitationKey(path, entry_key)] = citation
+        self.citations[citation.key] = citation
 
         return citation
 

--- a/duecredit/collector.py
+++ b/duecredit/collector.py
@@ -240,7 +240,7 @@ class DueCreditCollector(object):
 
         entry_key = entry_.get_key()
         if (path, entry_key) not in self.citations:
-           self.citations[(path, entry_key)]  = Citation(entry_, **kwargs)
+           self.citations[(path, entry_key)] = Citation(entry_, **kwargs)
         citation = self.citations[(path, entry_key)]
         # update citation count
         citation.count += 1

--- a/duecredit/collector.py
+++ b/duecredit/collector.py
@@ -162,6 +162,10 @@ class Citation(object):
     def key(self):
         return CitationKey(self.path, self.entry.get_key())
 
+    @staticmethod
+    def get_key(path, entry_key):
+        return CitationKey(path, entry_key)
+
 
 class DueCreditCollector(object):
     """Collect the references
@@ -239,9 +243,12 @@ class DueCreditCollector(object):
             entry_ = self._entries[entry]
 
         entry_key = entry_.get_key()
-        if (path, entry_key) not in self.citations:
-           self.citations[(path, entry_key)] = Citation(entry_, **kwargs)
-        citation = self.citations[(path, entry_key)]
+        citation_key = Citation.get_key(path=path, entry_key=entry_key)
+        try:
+            citation = self.citations[citation_key]
+        except KeyError:
+            self.citations[citation_key] = citation = Citation(entry_, **kwargs)
+        assert(citation.key == citation_key)
         # update citation count
         citation.count += 1
 

--- a/duecredit/collector.py
+++ b/duecredit/collector.py
@@ -275,7 +275,7 @@ class DueCreditCollector(object):
 
         return citation
 
-    def citations_fromentrykey(self):
+    def _citations_fromentrykey(self):
         """Return a dictionary with the current citations indexed by the entry key"""
         citations_key = dict()
         for (path, entry_key), citation in iteritems(self.citations):

--- a/duecredit/collector.py
+++ b/duecredit/collector.py
@@ -71,7 +71,6 @@ class Citation(object):
         # We might want extract all the relevant functionality into a separate class
         self._path = path
         self._cite_module = cite_module
-        self.count = 0
         self.tags = tags or []
         self.version = version
 

--- a/duecredit/collector.py
+++ b/duecredit/collector.py
@@ -267,9 +267,8 @@ class DueCreditCollector(object):
 
     def citations_fromentrykey(self):
         """Return a dictionary with the current citations indexed by the entry key"""
-        citations = self.citations
         citations_key = dict()
-        for (path, entry_key), citation in iteritems(citations):
+        for (path, entry_key), citation in iteritems(self.citations):
             if entry_key not in citations_key:
                 citations_key[entry_key] = citation
 

--- a/duecredit/collector.py
+++ b/duecredit/collector.py
@@ -19,10 +19,12 @@ from .entries import DueCreditEntry
 from .stub import InactiveDueCreditCollector
 from .io import TextOutput, PickleOutput
 from .utils import never_fail, borrowdoc, external_versions
+from collections import namedtuple
 
 import logging
 lgr = logging.getLogger('duecredit.collector')
 
+CitationKey = namedtuple('CitationKey', ['path', 'entry_key'])
 
 class Citation(object):
     """Encapsulates citations and information on their use"""
@@ -257,7 +259,7 @@ class DueCreditCollector(object):
                 version = external_versions[package]
             citation.version = version
 
-        self.citations[(path, entry_key)] = citation
+        self.citations[CitationKey(path, entry_key)] = citation
 
         return citation
 

--- a/duecredit/collector.py
+++ b/duecredit/collector.py
@@ -263,6 +263,17 @@ class DueCreditCollector(object):
 
         return citation
 
+    def citations_fromentrykey(self):
+        """Return a dictionary with the current citations indexed by the entry key"""
+        citations = self.citations
+        citations_key = dict()
+        for (path, entry_key), citation in iteritems(citations):
+            if entry_key not in citations_key:
+                citations_key[entry_key] = citation
+
+        return citations_key
+
+
     @staticmethod
     def _args_match_conditions(conditions, *fargs, **fkwargs):
         """Helper to identify when to trigger citation given parameters to the function call

--- a/duecredit/entries.py
+++ b/duecredit/entries.py
@@ -14,7 +14,6 @@ class DueCreditEntry(object):
     def __init__(self, rawentry, key=None):
         self._rawentry = rawentry
         self._key = key or rawentry.lower()
-        self.count = 0
 
     def get_key(self):
         return self._key

--- a/duecredit/entries.py
+++ b/duecredit/entries.py
@@ -14,6 +14,7 @@ class DueCreditEntry(object):
     def __init__(self, rawentry, key=None):
         self._rawentry = rawentry
         self._key = key or rawentry.lower()
+        self.count = 0
 
     def get_key(self):
         return self._key

--- a/duecredit/injections/mod_scipy.py
+++ b/duecredit/injections/mod_scipy.py
@@ -163,8 +163,7 @@ def inject(injector):
 
     injector.add('scipy.cluster.hierarchy', 'linkage', BibTeX("""
     @article{sibson1973slink,
-        title={SLINK: an optimally efficient algorithm for the single-link
-        cluster method},
+        title={SLINK: an optimally efficient algorithm for the single-link cluster method},
         author={Sibson, Robin},
         journal={The Computer Journal},
         volume={16},

--- a/duecredit/io.py
+++ b/duecredit/io.py
@@ -111,14 +111,14 @@ class TextOutput(object):  # TODO some parent class to do what...?
                     refnr += 1
             citations_ordered.append(package)
             # module level
-            for module in sorted(filter(lambda x: package + '.' in x, modules['entry_keys'])):
+            for module in sorted(filter(lambda x: package in x, modules['entry_keys'])):
                 for entry_key_mod in modules['entry_keys'][module]:
                     if entry_key_mod not in keys2refnr:
                         keys2refnr[entry_key_mod] = refnr
                         refnr += 1
                 citations_ordered.append(module)
             # object level
-            for obj in sorted(filter(lambda x: package + '.' in x, objects['entry_keys'])):
+            for obj in sorted(filter(lambda x: package in x, objects['entry_keys'])):
                 for entry_key_obj in objects['entry_keys'][obj]:
                     if entry_key_obj not in keys2refnr:
                         keys2refnr[entry_key_obj] = refnr

--- a/duecredit/io.py
+++ b/duecredit/io.py
@@ -84,14 +84,13 @@ class TextOutput(object):  # TODO some parent class to do what...?
         # for each path store both a list of entry keys and of citations
         for (path, entry_key), citation in iteritems(citations):
             if ':' in path:
-                objects['citations'][path].append(citation)
-                objects['entry_keys'][path].append(entry_key)
+                target_dict = objects
             elif '.' in path:
-                modules['citations'][path].append(citation)
-                modules['entry_keys'][path].append(entry_key)
+                target_dict = modules
             else:
-                packages['citations'][path].append(citation)
-                packages['entry_keys'][path].append(entry_key)
+                target_dict = packages
+            target_dict['citations'][path].append(citation)
+            target_dict['entry_keys'][path].append(entry_key)
         return packages, modules, objects
 
     def dump(self, tags=None):

--- a/duecredit/io.py
+++ b/duecredit/io.py
@@ -76,6 +76,10 @@ class EnumeratedEntries(Iterator):
     def __iter__(self):
         return iteritems(self._keys2refnr)
 
+    # Python 3
+    def __next__(self):
+        return self.next()
+
     def next(self):
         yield next(self.__iter__())
 

--- a/duecredit/io.py
+++ b/duecredit/io.py
@@ -138,20 +138,17 @@ class TextOutput(object):  # TODO some parent class to do what...?
         # set up view
 
         # package level
+        sublevels = [modules, objects]
         for package in sorted(packages['entry_keys']):
             for entry_key in packages['entry_keys'][package]:
                 enum_entries.add(entry_key)
             citations_ordered.append(package)
-            # module level
-            for module in sorted(filter(lambda x: package in x, modules['entry_keys'])):
-                for entry_key_mod in modules['entry_keys'][module]:
-                    enum_entries.add(entry_key_mod)
-                citations_ordered.append(module)
-            # object level
-            for obj in sorted(filter(lambda x: package in x, objects['entry_keys'])):
-                for entry_key_obj in objects['entry_keys'][obj]:
-                    enum_entries.add(entry_key_obj)
-                citations_ordered.append(obj)
+            # sublevels
+            for sublevel in sublevels:
+                for obj in sorted(filter(lambda x: package in x, sublevel['entry_keys'])):
+                    for entry_key_obj in sublevel['entry_keys'][obj]:
+                        enum_entries.add(entry_key_obj)
+                    citations_ordered.append(obj)
 
         # Now we can "render" different views of our "model"
         # Here for now just text BUT that is where we can "split" the logic and provide

--- a/duecredit/io.py
+++ b/duecredit/io.py
@@ -132,15 +132,14 @@ class TextOutput(object):  # TODO some parent class to do what...?
         for path in citations_ordered:
             if ':' in path:
                 self.fd.write('  ')
-                citations = objects['citations'][path]
-                entry_keys = objects['entry_keys'][path]
+                target_dict = objects
             elif '.' in path:
                 self.fd.write('  ')
-                citations = modules['citations'][path]
-                entry_keys = modules['entry_keys'][path]
+                target_dict = modules
             else:
-                citations = packages['citations'][path]
-                entry_keys = packages['entry_keys'][path]
+                target_dict = packages
+            citations = target_dict['citations'][path]
+            entry_keys = target_dict['entry_keys'][path]
             versions = sorted(map(str, set(str(r.version) for r in citations)))
             refnrs = sorted([str(keys2refnr[entry_key]) for entry_key in entry_keys])
             self.fd.write('- {0} (v {1}) [{2}]\n'.format(path, ' '.join(versions), ', '.join(refnrs)))

--- a/duecredit/io.py
+++ b/duecredit/io.py
@@ -1,7 +1,7 @@
 from citeproc.source.bibtex import BibTeX as cpBibTeX
 import citeproc as cp
 
-from collections import defaultdict
+from collections import defaultdict, Iterator
 import os
 from os.path import dirname, exists
 import pickle
@@ -47,7 +47,6 @@ def import_doi(doi):
                 f.write(bibtex)
     return bibtex
 
-from collections import Iterator
 
 class EnumeratedEntries(Iterator):
     """A container of entries enumerated referenced by their entry_key"""

--- a/duecredit/io.py
+++ b/duecredit/io.py
@@ -180,7 +180,7 @@ class TextOutput(object):  # TODO some parent class to do what...?
             self.fd.write('\n{0} {1} cited'.format(n, citation_type))
 
         if enum_entries:
-            citations_fromentrykey = self.collector.citations_fromentrykey()
+            citations_fromentrykey = self.collector._citations_fromentrykey()
             self.fd.write('\n\nReferences\n' + '-' * 10 + '\n')
             # collect all the entries used
             refnr_key = [(nr, enum_entries.fromrefnr(nr)) for nr in range(1, len(enum_entries)+1)]

--- a/duecredit/stub.py
+++ b/duecredit/stub.py
@@ -41,7 +41,7 @@ class InactiveDueCreditCollector(object):
              return func
         return nondecorating_decorator
 
-    cite = load = add = _donothing
+    cite = load = add = citations_fromentrykey = _donothing
 
     def __repr__(self):
         return self.__class__.__name__ + '()'

--- a/duecredit/stub.py
+++ b/duecredit/stub.py
@@ -41,7 +41,7 @@ class InactiveDueCreditCollector(object):
              return func
         return nondecorating_decorator
 
-    cite = load = add = citations_fromentrykey = _donothing
+    cite = load = add =  _donothing
 
     def __repr__(self):
         return self.__class__.__name__ + '()'

--- a/duecredit/tests/test_collector.py
+++ b/duecredit/tests/test_collector.py
@@ -124,7 +124,7 @@ def test_dcite_method():
             assert_equal(len(due.citations), 1)
             assert_equal(len(due._entries), 1)
             citation = due.citations[("method", "XXX0")]
-            assert_equal(due._entries['XXX0'].count, 1)
+            assert_equal(citation.count, 1)
             # TODO: this is probably incomplete path but unlikely we would know
             # any better
             assert_equal(citation.path, "method")
@@ -135,11 +135,10 @@ def test_dcite_method():
         if active:
             assert_equal(len(due.citations), 2)
             assert_equal(len(due._entries), 1)
-            assert_equal(due._entries['XXX0'].count, 2)
             # TODO: we should actually get path/counts pairs so here
             citation = due.citations[("someclass:method", "XXX0")]
             assert_equal(citation.path, "someclass:method")
-            # it is already a different path
+            assert_equal(citation.count, 1)
 
             # And we explicitly stated that module need to be cited
             assert_true(citation.cite_module)
@@ -213,22 +212,21 @@ def test_dcite_match_conditions():
     assert_equal(len(due.citations), 1)
     assert_equal(len(due._entries), 1)
     entry = due._entries['XXX0']
-    assert_equal(entry.count, 1)
+    assert_equal(due.citations[('method', 'XXX0')].count, 1)
 
     # Cause the same citation
     assert_equal(method("magical", "blah"), "load blah")
     # Nothing should change
     assert_equal(len(due.citations), 1)
     assert_equal(len(due._entries), 1)
-    assert_equal(entry.count, 2)  # Besides the count
+    assert_equal(due.citations[('method', 'XXX0')].count, 2) # Besides the count
 
     # Now cause new citation given another value
     assert_equal(method("magical", "boo"), "load boo")
     assert_equal(len(due.citations), 2)
     assert_equal(len(due._entries), 2)
-    assert_equal(entry.count, 2)  # Count should stay the same for XXX0
-    assert_equal(due._entries[_sample_doi].count, 1) # And we got one new
-    # counted
+    assert_equal(due.citations[('method', 'XXX0')].count, 2) # Count should stay the same for XXX0
+    assert_equal(due.citations[('method', 'a.b.c/1.2.3')].count, 1) # but we get a new one
 
 
 

--- a/duecredit/tests/test_collector.py
+++ b/duecredit/tests/test_collector.py
@@ -156,9 +156,8 @@ def test_dcite_method():
 
         yield _test_dcite_basic, due, instance2.method
         if active:
-            assert_equal(len(due.citations), 1)
+            assert_equal(len(due.citations), 2)  # different paths
             assert_equal(len(due._entries), 1) # the same entry
-            assert_equal(citation.count, 3)
             # TODO: we should actually get path/counts pairs so here
             # it is already a different path
             # And we still explicitly stated that module need to be cited

--- a/duecredit/tests/test_io.py
+++ b/duecredit/tests/test_io.py
@@ -150,7 +150,7 @@ def test_text_output_dump_formatting():
     reference_numbers = []
     references = []
     for line in lines:
-        match_citation = re.search('\[(.+)\]$', line)
+        match_citation = re.search('\[([0-9, ]+)\]$', line)
         match_reference = re.search('^\[([0-9])\]', line)
         if match_citation:
             citation_numbers.extend(match_citation.group(1).split(', '))

--- a/duecredit/tests/test_io.py
+++ b/duecredit/tests/test_io.py
@@ -1,8 +1,8 @@
 from ..collector import DueCreditCollector
 from ..entries import BibTeX, DueCreditEntry
-from ..io import TextOutput, PickleOutput, import_doi
+from ..io import TextOutput, PickleOutput, import_doi, EnumeratedEntries
 from nose.tools import assert_equal, assert_is_instance, assert_raises, \
-    assert_true
+    assert_true, assert_false
 from six.moves import StringIO
 from six import text_type
 
@@ -191,3 +191,23 @@ def _generate_sample_bibtex():
         sample_bibtex += "%s={%s},\n" % (string, value)
     sample_bibtex += "}"
     return sample_bibtex
+
+def test_enumeratedentries():
+    enumentries = EnumeratedEntries()
+    assert_false(enumentries)
+
+    # add some entries
+    entries = [('ciao', 1), ('miao', 2), ('bau', 3)]
+    for entry, _ in entries:
+        enumentries.add(entry)
+
+    assert_equal(len(enumentries), 3)
+
+    for entry, nr in entries:
+        assert_equal(nr, enumentries[entry])
+        assert_equal(entry, enumentries.fromrefnr(nr))
+
+    assert_raises(KeyError, enumentries.__getitem__, 'boh')
+    assert_raises(KeyError, enumentries.fromrefnr, 666)
+
+    assert_equal(entries, sorted(enumentries, key=lambda x: x[1]))

--- a/duecredit/tests/test_io.py
+++ b/duecredit/tests/test_io.py
@@ -45,7 +45,7 @@ def test_pickleoutput():
                    "pages={491-492}\n}")
     collector_ = DueCreditCollector()
     collector_.add(entry)
-    collector_.cite(entry)
+    collector_.cite(entry, path='module')
 
     # test it doesn't puke with an empty collector
     collectors = [collector_, DueCreditCollector()]
@@ -66,7 +66,7 @@ def test_pickleoutput():
 def test_text_output():
     entry = BibTeX(_sample_bibtex)
     collector = DueCreditCollector()
-    collector.cite(entry)
+    collector.cite(entry, path='module')
 
     strio = StringIO()
     TextOutput(strio, collector).dump(tags=['*'])

--- a/duecredit/tests/test_io.py
+++ b/duecredit/tests/test_io.py
@@ -106,11 +106,11 @@ def test_text_output_dump_formatting():
     mymodule('magical', kwarg2=1)
     TextOutput(strio, due).dump(tags=['*'])
     value = strio.getvalue()
-    assert_true('1 modules cited' in value, msg='value was {0}'.format(value))
+    assert_true('1 packages cited' in value, msg='value was {0}'.format(value))
     assert_true('1 functions cited' in value, msg='value was {0}'.format(value))
     assert_true('(v 0.0.16)' in value,
                 msg='value was {0}'.format(value))
-    assert_equal(len(value.split('\n')), 18, msg='value was {0}'.format(value))
+    assert_equal(len(value.split('\n')), 19, msg='value was {0}'.format(value))
 
     # test we get the reference numbering right
     samples_bibtex = [_generate_sample_bibtex() for x in range(5)]

--- a/duecredit/tests/test_io.py
+++ b/duecredit/tests/test_io.py
@@ -132,7 +132,6 @@ def test_text_output_dump_formatting():
                    path='myothermodule:myotherfunction')
         @due.dcite(BibTeX(samples_bibtex[4]), description='solution to life',
                    path='myothermodule:myotherfunction')
-        # XXX: atm cross-referencing doesn't work
         @due.dcite(BibTeX(_sample_bibtex2), description='solution to life',
                    path='myothermodule:myotherfunction')
         def myotherfunction(arg42):
@@ -151,12 +150,12 @@ def test_text_output_dump_formatting():
     reference_numbers = []
     references = []
     for line in lines:
-        match_citation = re.search('(\[[0-9]\])$', line)
-        match_reference = re.search('^(\[[0-9]\])', line)
+        match_citation = re.search('\[(.+)\]$', line)
+        match_reference = re.search('^\[([0-9])\]', line)
         if match_citation:
-            citation_numbers.append(match_citation.group())
+            citation_numbers.extend(match_citation.group(1).split(', '))
         elif match_reference:
-            reference_numbers.append(match_reference.group())
+            reference_numbers.append(match_reference.group(1))
             references.append(line.replace(match_reference.group(), ""))
 
     assert_equal(set(citation_numbers), set(reference_numbers))

--- a/duecredit/tests/test_io.py
+++ b/duecredit/tests/test_io.py
@@ -133,8 +133,8 @@ def test_text_output_dump_formatting():
         @due.dcite(BibTeX(samples_bibtex[4]), description='solution to life',
                    path='myothermodule:myotherfunction')
         # XXX: atm cross-referencing doesn't work
-        # @due.dcite(BibTeX(_sample_bibtex2), description='solution to life',
-        #           path='myothermodule:myotherfunction')
+        @due.dcite(BibTeX(_sample_bibtex2), description='solution to life',
+                   path='myothermodule:myotherfunction')
         def myotherfunction(arg42):
             pass
 
@@ -159,8 +159,9 @@ def test_text_output_dump_formatting():
             reference_numbers.append(match_reference.group())
             references.append(line.replace(match_reference.group(), ""))
 
-    assert_equal(citation_numbers, reference_numbers)
-    assert_equal(len(set(references)), len(citation_numbers))
+    assert_equal(set(citation_numbers), set(reference_numbers))
+    assert_equal(len(set(references)), len(set(citation_numbers)))
+    assert_equal(len(citation_numbers), 8)
     # verify that we have returned to previous state of filters
     import warnings
     assert_true(('ignore', None, UserWarning, None, 0) not in warnings.filters)


### PR DESCRIPTION
Took me a while, but works. It could be made prettier though.
Fixes #30, passes #32.

The biggest change is that now `path` must be specified in the citation (or we have to get it automatically), because the citation is stored according to a tuple `(path, entry_key)`.