### PR TITLE
BF: Fix get_text_rendering when Citation is passed with Doi

### DIFF
--- a/duecredit/collector.py
+++ b/duecredit/collector.py
@@ -167,6 +167,9 @@ class Citation(object):
     def get_key(path, entry_key):
         return CitationKey(path, entry_key)
 
+    def set_entry(self, newentry):
+        self._entry = newentry
+
 
 class DueCreditCollector(object):
     """Collect the references

--- a/duecredit/io.py
+++ b/duecredit/io.py
@@ -2,6 +2,7 @@ from citeproc.source.bibtex import BibTeX as cpBibTeX
 import citeproc as cp
 
 from collections import defaultdict, Iterator
+import copy
 import os
 from os.path import dirname, exists
 import pickle
@@ -194,13 +195,8 @@ def get_text_rendering(citation, style='harvard1'):
     entry = citation.entry
     if isinstance(entry, Doi):
         bibtex_rendering = get_bibtex_rendering(entry)
-        # pass down the kwargs
-        bibtex_citation = Citation(bibtex_rendering,
-                                   description=citation.description,
-                                   path=citation.path,
-                                   version=citation.version,
-                                   cite_module=citation.cite_module,
-                                   tags=citation.tags)
+        bibtex_citation = copy.copy(citation)
+        bibtex_citation.set_entry(bibtex_rendering)
         return get_text_rendering(bibtex_citation)
     elif isinstance(entry, BibTeX):
         return format_bibtex(entry, style=style)

--- a/duecredit/tests/test_collector.py
+++ b/duecredit/tests/test_collector.py
@@ -269,7 +269,7 @@ def test_dcite_match_conditions_method():
     citeable = Citeable(param="paramvalue")
     _test_dcite_match_conditions(due, citeable.method, 'obj.callable')
 
-    # now test for self.param
+    # now test for self.param -
 
 
 def test_get_output_handler_method():

--- a/duecredit/tests/test_collector.py
+++ b/duecredit/tests/test_collector.py
@@ -235,7 +235,7 @@ def test_dcite_match_conditions():
     assert_equal(len(due.citations), 2)
     assert_equal(len(due._entries), 2)
     assert_equal(due.citations[('method', 'XXX0')].count, 2) # Count should stay the same for XXX0
-    assert_equal(due.citations[('method', 'a.b.c/1.2.3')].count, 1) # but we get a new one
+    assert_equal(due.citations[('method', _sample_doi)].count, 1) # but we get a new one
 
 
 

--- a/duecredit/tests/test_collector.py
+++ b/duecredit/tests/test_collector.py
@@ -50,7 +50,7 @@ _sample_bibtex2 = """
   month = {Jul},
 }
 """
-_sample_doi = "a.b.c/1.2.3"
+_sample_doi = "10.3389/fninf.2012.00022"
 
 def test_citation_paths():
     entry = BibTeX(_sample_bibtex)

--- a/duecredit/tests/test_collector.py
+++ b/duecredit/tests/test_collector.py
@@ -226,7 +226,7 @@ def _test_dcite_match_conditions(due, callable, path):
     assert_equal(len(due.citations), 2)
     assert_equal(len(due._entries), 2)
     assert_equal(due.citations[(path, 'XXX0')].count, 2) # Count should stay the same for XXX0
-    assert_equal(due.citations[(path, 'a.b.c/1.2.3')].count, 1) # but we get a new one
+    assert_equal(due.citations[(path, "10.3389/fninf.2012.00022")].count, 1) # but we get a new one
 
 
 def test_dcite_match_conditions_function():

--- a/duecredit/tests/test_io.py
+++ b/duecredit/tests/test_io.py
@@ -224,11 +224,13 @@ def test_get_text_rendering(mock_format_bibtex, mock_get_bibtex_rendering):
 
     # test if bibtex type is passed
     citation_bibtex = Citation(sample_bibtex, path='mypath')
-    assert_true(get_text_rendering(citation_bibtex))
+    bibtex_output = get_text_rendering(citation_bibtex)
     mock_format_bibtex.assert_called_with(citation_bibtex.entry, style='harvard1')
     mock_format_bibtex.reset_mock()
 
     # test if doi type is passed
     citation_doi = Citation(Doi(_sample_doi), path='mypath')
-    assert_true(get_text_rendering(citation_doi))
+    doi_output = get_text_rendering(citation_doi)
     mock_format_bibtex.assert_called_with(citation_bibtex.entry, style='harvard1')
+
+    assert_equal(bibtex_output, doi_output)


### PR DESCRIPTION
We're getting there... however there is still a problem with the injector because there should be two citations for spectral clustering (see below), but only one appears...probably due to how they're stored. Will look into that.

```
(duecredit)contematto@talete ~/github/scikit-learn/examples/cluster (master*) $ python -m duecredit plot_cluster_comparison.py

=========================================================
Comparing different clustering algorithms on toy datasets
=========================================================

This example aims at showing characteristics of different
clustering algorithms on datasets that are "interesting"
but still in 2D. The last dataset is an example of a 'null'
situation for clustering: the data is homogeneous, and
there is no good clustering.

While these examples give some intuition about the algorithms,
this intuition might not apply to very high dimensional data.

The results could be improved by tweaking the parameters for
each clustering strategy, for instance setting the number of
clusters for the methods that needs this parameter
specified. Note that affinity propagation has a tendency to
create many clusters. Thus in this example its two parameters
(damping and per-point preference) were set to to mitigate this
behavior.

/Users/contematto/virtualenv/duecredit/lib/python2.7/site-packages/sklearn/manifold/spectral_embedding_.py:217: UserWarning: Graph is not fully connected, spectral embedding may not work as expected.
  warnings.warn("Graph is not fully connected, spectral embedding"
/Users/contematto/virtualenv/duecredit/lib/python2.7/site-packages/sklearn/cluster/hierarchical.py:207: UserWarning: the number of connected components of the connectivity matrix is 2 > 1. Completing it to avoid stopping the tree early.
  connectivity, n_components = _fix_connectivity(X, connectivity)
/Users/contematto/virtualenv/duecredit/lib/python2.7/site-packages/sklearn/cluster/hierarchical.py:443: UserWarning: the number of connected components of the connectivity matrix is 2 > 1. Completing it to avoid stopping the tree early.
  connectivity, n_components = _fix_connectivity(X, connectivity)
/Users/contematto/virtualenv/duecredit/lib/python2.7/site-packages/sklearn/cluster/hierarchical.py:207: UserWarning: the number of connected components of the connectivity matrix is 3 > 1. Completing it to avoid stopping the tree early.
  connectivity, n_components = _fix_connectivity(X, connectivity)
/Users/contematto/virtualenv/duecredit/lib/python2.7/site-packages/sklearn/cluster/hierarchical.py:443: UserWarning: the number of connected components of the connectivity matrix is 3 > 1. Completing it to avoid stopping the tree early.
  connectivity, n_components = _fix_connectivity(X, connectivity)

DueCredit Report:
- scipy (v 0.14) [1]
- sklearn (v 0.17.dev0) [2]
  - sklearn.cluster.affinity_propagation_ (v 0.17.dev0) [3]
  - sklearn.cluster.dbscan_:dbscan (v 0.17.dev0) [4]
  - sklearn.cluster.spectral:spectral_clustering (v 0.17.dev0) [5]

2 packages cited
1 modules cited
2 functions cited

References
----------

[1] Jones, E. et al., 2001. SciPy: Open source scientific tools for Python.
[2] Pedregosa, F. et al., 2011. Scikit-learn: Machine learning in Python. The Journal of Machine Learning Research, 12, pp.2825–2830.
[3] Frey, B.J. & Dueck, D., 2007. Clustering by Passing Messages Between Data Points. Science, 315(5814), pp.972–976.
[4] Ester, M. et al., 1996. A density-based algorithm for discovering clusters in large spatial databases with noise.. In Kdd. pp. 226–231.
[5] von Luxburg, U., 2007. A tutorial on spectral clustering. Stat Comput, 17(4), pp.395–416.
```