### PR TITLE
BF: print description, not just path. Closes #49

### DIFF
--- a/duecredit/io.py
+++ b/duecredit/io.py
@@ -167,11 +167,14 @@ class TextOutput(object):  # TODO some parent class to do what...?
                 target_dict = modules
             else:
                 target_dict = packages
+            # TODO: absorb common logic into a common function
             citations = target_dict['citations'][path]
             entry_keys = target_dict['entry_keys'][path]
+            descriptions = sorted(map(str, set(str(r.description) for r in citations)))
             versions = sorted(map(str, set(str(r.version) for r in citations)))
             refnrs = sorted([str(enum_entries[entry_key]) for entry_key in entry_keys])
-            self.fd.write('- {0} (v {1}) [{2}]\n'.format(path, ' '.join(versions), ', '.join(refnrs)))
+            self.fd.write('- {0} / {1} (v {2}) [{3}]\n'.format(
+                ", ".join(descriptions), path, ', '.join(versions), ', '.join(refnrs)))
 
         # Print out some stats
         obj_names = ('packages', 'modules', 'functions')


### PR DESCRIPTION
will look now like

```
$> duecredit summary

DueCredit Report:
- LIBSVM: A library for support vector machines / libsvm (v None) [1]
- Multivariate pattern analysis of neural data / mvpa2 (v 2.4) [2]
  - Support Vector Machines (SVM) / mvpa2.clfs.SVM (v 2.4) [3]
  - Sparse multinomial-logistic regression classifier / mvpa2.clfs.smlr:SMLR (v 2.4) [4]
  - Bayesian hypothesis testing / mvpa2.clfs.transerror:_call (v 2.4) [5]
  - Recursive feature elimination procedure / mvpa2.featsel.rfe:_train (v 2.4) [6]
  - Searchlight analysis approach / mvpa2.measures.searchlight:_call (v 2.4) [7]
- Scientific tools library / scipy (v 0.14.1) [8]
- Machine Learning library / sklearn (v 0.16.1) [9]
  - Random forest classifiers / sklearn.ensemble.forest:RandomForestClassifier.predict_proba (v 0.16.1) [10]
  - Classification and regression trees / sklearn.tree.tree:DecisionTreeClassifier.predict_proba (v 0.16.1) [11]

4 packages cited
1 modules cited
...
```