### PR TITLE
BF: allow multiple injections at the same path, avoid resetting _orig_import if already deactivated

### DIFF
--- a/duecredit/injections/injector.py
+++ b/duecredit/injections/injector.py
@@ -364,7 +364,7 @@ class DueCreditInjector(object):
             lgr.warning("_orig_import is not yet known, so we haven't decorated default importer yet."
                         " Nothing TODO")
             return
-        if not self._active:
+        if not self._active:  # pragma: no cover
             lgr.error("Must have not happened, but we will survive!")
         lgr.debug("Assigning original importer")
         __builtin__.__import__ = self._orig_import

--- a/duecredit/injections/injector.py
+++ b/duecredit/injections/injector.py
@@ -77,7 +77,19 @@ class DueCreditInjector(object):
     """
 
     # Made as a class variable to assure being singleton and available upon del
-    _orig_import = None
+    __orig_import = None
+
+    # and interact with its value through the property to ease tracking of actions
+    # performed on it
+    @property
+    def _orig_import(self):
+        return DueCreditInjector.__orig_import
+
+    @_orig_import.setter
+    def _orig_import(self, value):
+        lgr.log(2, "Reassigning _orig_import from %r to %r", DueCreditInjector.__orig_import, value)
+        DueCreditInjector.__orig_import = value
+
 
     def __init__(self, collector=None):
         if collector is None:
@@ -94,6 +106,8 @@ class DueCreditInjector(object):
         self.__import_level = 0
         self.__queue_to_process = set()
         self.__processing_queue = False
+        self._active = False
+        lgr.debug("Created injector %r", self)
 
     def _populate_delayed_injections(self):
         self._delayed_injections = {}
@@ -219,7 +233,7 @@ class DueCreditInjector(object):
     def _mitigate_None_orig_import(self, name, *args, **kwargs):
         lgr.error("For some reason self._orig_import is None"
                   ". Importing using stock importer to mitigate and adjusting _orig_import")
-        DueCreditInjector._orig_import = _very_orig_import
+        self._orig_import = _very_orig_import
         return _very_orig_import(name, *args, **kwargs)
 
     def activate(self, retrospect=True):
@@ -236,7 +250,7 @@ class DueCreditInjector(object):
             if hasattr(__builtin__.__import__, '__duecredited__'):
                 raise RuntimeError("__import__ is already duecredited")
 
-            DueCreditInjector._orig_import = __builtin__.__import__
+            self._orig_import = __builtin__.__import__
 
             @wraps(__builtin__.__import__)
             def __import(name, *args, **kwargs):
@@ -294,6 +308,7 @@ class DueCreditInjector(object):
 
             lgr.debug("Assigning our importer")
             __builtin__.__import__ = __import
+            self._active = True
 
         else:
             lgr.warning("Seems that we are calling duecredit_importer twice."
@@ -349,16 +364,19 @@ class DueCreditInjector(object):
             lgr.warning("_orig_import is not yet known, so we haven't decorated default importer yet."
                         " Nothing TODO")
             return
-
+        if not self._active:
+            lgr.error("Must have not happened, but we will survive!")
         lgr.debug("Assigning original importer")
         __builtin__.__import__ = self._orig_import
-        DueCreditInjector._orig_import = None
+        self._orig_import = None
+        self._active = False
 
     def __del__(self):
-        if self._orig_import is not None:
+        lgr.debug("%s is asked to be deleted", self)
+        if self._active:
             self.deactivate()
         try:
-            super(self.__class__, self)._del__()
+            super(self.__class__, self).__del__()
         except Exception:
             pass
 

--- a/duecredit/tests/test_injections.py
+++ b/duecredit/tests/test_injections.py
@@ -59,7 +59,7 @@ class TestActiveInjector(object):
         if 'duecredit.tests.mod' in sys.modules:
             sys.modules.pop('duecredit.tests.mod')
 
-    def _test_simple_injection(self, func, import_stmt, func_call=None, skip=False):
+    def _test_simple_injection(self, func, import_stmt, func_call=None):
         assert_false('duecredit.tests.mod' in sys.modules)
         self.injector.add('duecredit.tests.mod', func,
                           Doi('1.2.3.4'),
@@ -73,8 +73,6 @@ class TestActiveInjector(object):
         globals_, locals_ = {}, {}
         exec(import_stmt, globals_, locals_)
 
-        if skip:
-            raise SkipTest("cowardly skipping a known failure on travis")
         assert_equal(len(self.due._entries), 1)   # we should get an entry now
         assert_equal(len(self.due.citations), 0)  # but not yet a citation
 
@@ -101,7 +99,7 @@ class TestActiveInjector(object):
 
         assert(citation.tags == ['implementation', 'very custom'])
 
-    def _test_double_injection(self, func, import_stmt, func_call=None, skip=False):
+    def _test_double_injection(self, func, import_stmt, func_call=None):
         assert_false('duecredit.tests.mod' in sys.modules)
         # add one injection
         self.injector.add('duecredit.tests.mod', func,
@@ -122,8 +120,6 @@ class TestActiveInjector(object):
         globals_, locals_ = {}, {}
         exec(import_stmt, globals_, locals_)
 
-        if skip:
-            raise SkipTest("cowardly skipping a known failure on travis")
         assert_equal(len(self.due._entries), 2)   # we should get two entries now
         assert_equal(len(self.due.citations), 0)  # but not yet a citation
 
@@ -151,32 +147,14 @@ class TestActiveInjector(object):
         assert(citation.tags == ['implementation', 'very custom'])
 
     def test_simple_injection(self):
-        # yoh can't figure out that ugly test failure which
-        # 1. seems to appear in origin/master...ddc70b5
-        # 2. doesn't reproduce on other python environments there
-        # 3. doesn't reproduce even if I login into that travis env with nearly identical everything
-        # So -- yoh gives up.  If you are young and brave, see e.g.
-        # https://travis-ci.org/duecredit/duecredit/builds/127939664
-        allow_first_failure = os.environ.get('TRAVIS_PYTHON_VERSION', '') == "2.7" or \
-            '\\appveyor' in str(os.environ).lower()
-
-        yield self._test_simple_injection, "testfunc1", 'from duecredit.tests.mod import testfunc1', None, allow_first_failure
+        yield self._test_simple_injection, "testfunc1", 'from duecredit.tests.mod import testfunc1', None
         yield self._test_simple_injection, "TestClass1.testmeth1", \
               'from duecredit.tests.mod import TestClass1; c = TestClass1()', 'c.testmeth1'
         yield self._test_simple_injection, "TestClass12.Embed.testmeth1", \
               'from duecredit.tests.mod import TestClass12; c = TestClass12.Embed()', 'c.testmeth1'
 
     def test_double_injection(self):
-        # yoh can't figure out that ugly test failure which
-        # 1. seems to appear in origin/master...ddc70b5
-        # 2. doesn't reproduce on other python environments there
-        # 3. doesn't reproduce even if I login into that travis env with nearly identical everything
-        # So -- yoh gives up.  If you are young and brave, see e.g.
-        # https://travis-ci.org/duecredit/duecredit/builds/127939664
-        allow_first_failure = os.environ.get('TRAVIS_PYTHON_VERSION', '') == "2.7" or \
-                              '\\appveyor' in str(os.environ).lower()
-
-        yield self._test_double_injection, "testfunc1", 'from duecredit.tests.mod import testfunc1', None, allow_first_failure
+        yield self._test_double_injection, "testfunc1", 'from duecredit.tests.mod import testfunc1', None
         yield self._test_double_injection, "TestClass1.testmeth1", \
                'from duecredit.tests.mod import TestClass1; c = TestClass1()', 'c.testmeth1'
         yield self._test_double_injection, "TestClass12.Embed.testmeth1", \

--- a/setup.py
+++ b/setup.py
@@ -61,9 +61,10 @@ except OSError as e:
     if os.path.exists(VERSION_FILE):
         with open(VERSION_FILE) as version_file:
             code = compile(version_file.read(), VERSION_FILE, 'exec')
-            exec(code, {}, {})
+            exec(code, locals(), globals())
     else:
         __version__ = '0.0.0.dev'
+print("Version: %s" % __version__)
 
 with open('README.md') as file:
     README = file.read()


### PR DESCRIPTION
now also avoids side-effect of del resetting orig_import when it mustn't

Closes #88 #47 #90 