### PR TITLE
BF: do not create cache directory until needed

### DIFF
--- a/duecredit/dueswitch.py
+++ b/duecredit/dueswitch.py
@@ -34,10 +34,6 @@ def _get_active_due():
     from .config import CACHE_DIR, DUECREDIT_FILE
     from duecredit.collector import CollectorSummary, DueCreditCollector
     from .io import load_due
-    import atexit
-    # where to cache bibtex entries
-    if not os.path.exists(CACHE_DIR):
-        os.makedirs(CACHE_DIR)
 
     # TODO:  this needs to move to atexit handling, that we load previous
     # one and them merge with new ones.  Informative bits could be -- how

--- a/duecredit/io.py
+++ b/duecredit/io.py
@@ -32,6 +32,9 @@ _PREFERRED_ENCODING = locale.getpreferredencoding()
 
 
 def get_doi_cache_file(doi):
+    # where to cache bibtex entries
+    if not os.path.exists(CACHE_DIR):
+        os.makedirs(CACHE_DIR)
     return os.path.join(CACHE_DIR, doi)
 
 


### PR DESCRIPTION
Closes #104 
I am yet not sure why `pip install duecredit` fetching it from pypi manages to invoke `_get_active_due` but  it seems to be the case. Moving in hope to get it resolved