### PR TITLE
added MDAnalysis as native duecredit user

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,5 +324,6 @@ request and add your project to this list. Thanks to
 - [pybids](https://github.com/INCF/pybids)
 - [Quickshear](https://github.com/nipy/quickshear)
 - [meqc](https://github.com/emdupre/meqc)
+- [MDAnalysis](https://www.mdanalysis.org)
 
 Last updated 2017-06-27.


### PR DESCRIPTION
MDAnalysis will support duecredit natively in the upcoming 0.18.0 release (see MDAnalysis/mdanalysis#412 and details in PR MDAnalysis/mdanalysis#1822 – namely we had to mock out duecredit's use of `os.fork` to avoid complications when running under MPI)