### PR TITLE
Default collector to stderr instead of stdout

### DIFF
--- a/duecredit/collector.py
+++ b/duecredit/collector.py
@@ -444,7 +444,7 @@ class DueCreditCollector(object):
 class CollectorSummary(object):
     """A helper which would take care about exporting citations upon its Death
     """
-    def __init__(self, collector, outputs="stdout,pickle", fn=DUECREDIT_FILE):
+    def __init__(self, collector, outputs="stderr,pickle", fn=DUECREDIT_FILE):
         self._due = collector
         self.fn = fn
         # for now decide on output "format" right here

--- a/duecredit/tests/test_api.py
+++ b/duecredit/tests/test_api.py
@@ -163,7 +163,6 @@ def test_noincorrect_import_if_no_lxml_numpy(monkeypatch, kwargs, env, stubbed_e
         monkeypatch.setitem(os.environ, key, fake_env_nolxml_[key])
 
     ret, out, err = run_python_command(**kwargs)
-    assert err == ''
     if os.environ.get('DUECREDIT_ENABLE', False) and on_windows:  # TODO this test fails on windows
         pytest.xfail("Fails for some reason on Windows")
     elif os.environ.get('DUECREDIT_ENABLE', False):  # we enabled duecredit
@@ -174,7 +173,7 @@ def test_noincorrect_import_if_no_lxml_numpy(monkeypatch, kwargs, env, stubbed_e
         else:
             # there was nothing to format so we did not fail for no reason
             assert 'For formatted output we need citeproc' not in out
-            assert '0 packages cited' in out
+            assert '0 packages cited' in err
         assert 'done123' in out
     elif os.environ.get('DUECREDIT_TEST_EARLY_IMPORT_ERROR'):
         assert 'ImportError' in out


### PR DESCRIPTION
Hello,

I'm working on adding duecredit to [dib-lab/sourmash](https://github.com/dib-lab/sourmash/pull/478) but I'm having issues during collection. By default the collector will print information to `stdout` (if I run with `DUECREDIT_ENABLE=yes`), but this breaks software that pipes the output to other commands.

I changed the default from `stdout` to `stderr` in the collector, but I can also figure out how to support another env var to allow choosing where to output the collector data.
(I opened this PR to see your feedback)

Also, thanks for this project, it's really cool!
