### PR TITLE
ENH: Delay import of requests

### DIFF
--- a/duecredit/io.py
+++ b/duecredit/io.py
@@ -19,7 +19,6 @@ from collections import defaultdict, Iterator
 import copy
 from os.path import dirname, exists
 import pickle
-import requests
 import tempfile
 from six import PY2, itervalues, iteritems
 import warnings
@@ -43,6 +42,7 @@ def get_doi_cache_file(doi):
 
 
 def import_doi(doi, sleep=0.5, retries=10):
+    import requests
     cached = get_doi_cache_file(doi)
 
     if exists(cached):


### PR DESCRIPTION
Packages that load duecredit pull in 326 modules, 312 of which are loaded with requests.

This change delays import of requests to the single function that requests is called from.