### PR TITLE
ENH: wrap every operation in __del__ with bare try/except to avoid any error

### DIFF
--- a/duecredit/injections/injector.py
+++ b/duecredit/injections/injector.py
@@ -371,11 +371,15 @@ class DueCreditInjector(object):
         self._active = False
 
     def __del__(self):
-        lgr.debug("%s is asked to be deleted", self)
-        if self._active:
-            self.deactivate()
+        if lgr:
+            lgr.debug("%s is asked to be deleted", self)
+        try:
+            if self._active:
+                self.deactivate()
+        except:  # noqa: E722
+            pass
         try:
             super(self.__class__, self).__del__()
-        except Exception:
+        except:  # noqa: E722
             pass
 


### PR DESCRIPTION
Well, duecredit should be stealth! but I ran into the case with datalad:

     $> rm .duecredit.p; DUECREDIT_ENABLE=1 python -m nose -s -v datalad/support/tests/test_gitrepo.py:test_GitRepo_gitignore                                                                                                                    datalad.support.tests.test_gitrepo.test_GitRepo_gitignore ... ok
     ...
     Exception AttributeError: "NoneType object has no attribute debug" in <bound method DueCreditInjector.__del__ of <duecredit.injections.injector.DueCreditInjector object at 0x7f5e169264d0>> ignored

so decided to silence it all.  It should be benign since seems to happen
only at the end of the process so there should be no harm of not fully
deactivating the injector