### PR TITLE
ENH: Provide more informative message whenever using older citeproc without encoding arg

### DIFF
--- a/duecredit/io.py
+++ b/duecredit/io.py
@@ -28,6 +28,7 @@ from time import sleep
 from .config import CACHE_DIR, DUECREDIT_FILE
 from .entries import BibTeX, Doi, Text, Url
 from .log import lgr
+from .versions import external_versions
 
 _PREFERRED_ENCODING = locale.getpreferredencoding()
 platform_system = platform.system().lower()
@@ -310,8 +311,16 @@ def format_bibtex(bibtex_entry, style='harvard1'):
                 # we should be able to provide encoding argument
                 bib_source = cpBibTeX(fname, encoding='utf-8')
         except Exception as e:
-            lgr.error("Failed to process BibTeX file %s: %s" % (fname, e))
-            return "ERRORED: %s" % str(e)
+            msg = "Failed to process BibTeX file %s: %s." % (fname, e)
+            citeproc_version = external_versions['citeproc']
+            if 'unexpected keyword argument' in str(e) and \
+                    citeproc_version and citeproc_version < '0.4':
+                err = "need a newer citeproc-py >= 0.4.0"
+                msg += " You might just " + err
+            else:
+                err = str(e)
+            lgr.error(msg)
+            return "ERRORED: %s" % err
         finally:
             # return warnings back
             warnings.filters = old_filters

--- a/duecredit/versions.py
+++ b/duecredit/versions.py
@@ -9,10 +9,12 @@
 """Module to help maintain a registry of versions for external modules etc
 """
 import sys
+import pkg_resources
 from os import linesep
 from six import string_types
 
 from distutils.version import StrictVersion, LooseVersion
+
 
 # To depict an unknown version, which can't be compared by mistake etc
 class UnknownVersion:
@@ -53,6 +55,19 @@ class ExternalVersions(object):
         if isinstance(version, tuple) or isinstance(version, list):
             #  Generate string representation
             version = ".".join(str(x) for x in version)
+
+        if not version:
+            # Try pkg_resources
+            # module name might be different, and I found no way to
+            # deduce it for citeproc which comes from "citeproc-py"
+            # distribution
+            modname = module.__name__
+            try:
+                version = pkg_resources.get_distribution(
+                    {'citeproc': 'citeproc-py'}.get(modname, modname)
+                ).version
+            except Exception:
+                pass  # oh well - no luck either
 
         if version:
             try:


### PR DESCRIPTION
    Elderly me forgot details of the issue since it happened years ago.
    So to get better idea when things fail - provide information that it
    is due to outdated citeproc
