### PR TITLE
Blow to initiate DueSwitch if either of collectors is None - so stub would choose InactiveCollector

### DIFF
--- a/duecredit/dueswitch.py
+++ b/duecredit/dueswitch.py
@@ -22,12 +22,12 @@ def _get_duecredit_enable():
                     "Use 'yes' or 'no', or '0' or '1'")
     return env_enable.lower() in ('1', 'yes', 'true')
 
+
 @never_fail
 def _get_inactive_due():
-    # keeping duplicate but separate so later we could even place it into a separate
-    # submodule to possibly minimize startup time impact even more
-    from .collector import InactiveDueCreditCollector
+    from .stub import InactiveDueCreditCollector
     return InactiveDueCreditCollector()
+
 
 @never_fail
 def _get_active_due():

--- a/duecredit/dueswitch.py
+++ b/duecredit/dueswitch.py
@@ -62,6 +62,11 @@ class DueSwitch(object):
         self.__active = None
         self.__collectors = {False: inactive, True: active}
         self.__activations_done = False
+        if not (inactive and active):
+            raise ValueError(
+                "Both inactive and active collectors should be provided. "
+                "Got active=%r, inactive=%r" % (active, inactive)
+            )
         self.activate(activate)
 
     @property

--- a/duecredit/tests/test_dueswitch.py
+++ b/duecredit/tests/test_dueswitch.py
@@ -11,7 +11,7 @@ import atexit
 import pytest
 
 from ..injections.injector import DueCreditInjector
-from ..dueswitch import due
+from ..dueswitch import DueSwitch, due
 
 
 def test_dueswitch_activate(monkeypatch):
@@ -39,3 +39,10 @@ def test_dueswitch_activate(monkeypatch):
     assert state["activate"] == 1
     assert state["register"] == 1
     assert state["register_func"] == due.dump
+
+
+def test_a_bad_one():
+    # We might get neither of those and should fail
+    # see https://github.com/duecredit/duecredit/issues/142
+    # So let's through ValueError right away
+    pytest.raises(ValueError, DueSwitch, None, None, True)


### PR DESCRIPTION
Unfortunately could no longer reproduce locally #142, and changes in 0.6.5 made it avoidable anyways.  But with these changes we should have a better chance to avoid similar gotchas

Closes #142 