### PR TITLE
ENH: provide equality comparison for entries

### DIFF
--- a/duecredit/entries.py
+++ b/duecredit/entries.py
@@ -10,10 +10,20 @@
 import re
 from six import PY2
 
+import logging
+lgr = logging.getLogger('duecredit.entries')
+
+
 class DueCreditEntry(object):
     def __init__(self, rawentry, key=None):
         self._rawentry = rawentry
         self._key = key or rawentry.lower()
+
+    def __eq__(self, other):
+        return (
+            (self._rawentry == other._rawentry) and
+            (self._key == other._key)
+        )
 
     def get_key(self):
         return self._key
@@ -49,6 +59,11 @@ class BibTeX(DueCreditEntry):
         self._key = None
         self._reference = None
         self._process_rawentry()
+        if key is not None:
+            # use the one provided, not the parsed one
+            lgr.debug("Replacing parsed key %s for BibTeX with the provided %s",
+                      self._key, key)
+            self._key = key
 
     def _process_rawentry(self):
         reg = re.match("\s*@(?P<type>\S*)\s*\{\s*(?P<key>\S*)\s*,.*",
@@ -65,14 +80,15 @@ class Text(DueCreditEntry):
 
 
 class Doi(DueCreditEntry):
-    def __init__(self, doi, key=None):
-        super(Doi, self).__init__(doi, key)
-        self.doi = doi
-        # TODO
+
+    @property
+    def doi(self):
+        return self._rawentry
 
 
 class Url(DueCreditEntry):
-    def __init__(self, url, key=None):
-        super(Url, self).__init__(url, key)
-        self.url = url
+
+    @property
+    def url(self):
+        return self._rawentry
 

--- a/duecredit/tests/test_entries.py
+++ b/duecredit/tests/test_entries.py
@@ -1,0 +1,38 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil; coding: utf-8 -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the duecredit package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+
+import random
+import re
+import pickle
+import os
+import pytest
+
+from six.moves import StringIO
+from six import text_type
+
+import duecredit.io
+from ..collector import DueCreditCollector, Citation
+from .test_collector import _sample_bibtex, _sample_doi, _sample_bibtex2
+from ..entries import BibTeX, Doi, Text, Url
+
+
+def test_comparison():
+    assert Text("123") == Text("123")
+    assert Text("123") != Text("124")
+    assert Text("123", 'key') == Text("123", 'key')
+    assert Text("123", 'key') != Text("123", 'key1')
+    assert Text("123", 'key') != Text("124", 'key')
+
+    assert Doi("123/1", 'key') == Doi("123/1", 'key')
+    assert Url("http://123/1", 'key') == Url("http://123/1", 'key')
+
+
+def test_sugaring_api():
+    assert Url("http://1.com").url == "http://1.com"
+    assert Doi("1.com").doi == "1.com"


### PR DESCRIPTION
Note that inequality comparison cannot be done on stubbed do_nothing
returned values.  We could have returned provided `*args`, `**kwargs` but
that would only add tiny performance load and not sure if would not
cause some side-effects.