### PR TITLE
RF: use isinstance instead of type().__name__ comparison

### DIFF
--- a/duecredit/stub.py
+++ b/duecredit/stub.py
@@ -24,7 +24,7 @@ Copyright:  2015-2019  DueCredit developers
 License:    BSD-2
 """
 
-__version__ = '0.0.7'
+__version__ = '0.0.8'
 
 
 class InactiveDueCreditCollector(object):
@@ -57,7 +57,7 @@ try:
         raise RuntimeError(
             "Imported due lacks .cite. DueCredit is now disabled")
 except Exception as e:
-    if type(e).__name__ not in ('ImportError', 'ModuleNotFoundError'):
+    if not isinstance(e, ImportError):
         import logging
         logging.getLogger("duecredit").error(
             "Failed to import duecredit due to %s" % str(e))


### PR DESCRIPTION
ModuleNotFoundError is a subclass of ImportError:
  https://docs.python.org/3/library/exceptions.html#exception-hierarchy
so we can safely check via isinstance.  Moreover, it seems that
whenever exception is raised without explicit instantiation
(raise ImportError), we do catch an instance, so should work fine.

And I found not explicit comment or commit description on why I used `type().__name__` here, may be just some paranoia

Thanks @effigies for the review/comment at https://github.com/duecredit/duecredit/pull/149#discussion_r264696840