### PR TITLE
Travis-ci: added support for ppc64le along with amd64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 # travis-ci.org definition for DueCredit build
 language: python
 sudo: false
+arch:
+  - amd64
+  - ppc64le
 python:
   - "2.7"
   - "3.5"
@@ -13,6 +16,9 @@ cache:
   - pip
 before_install:
   # - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then travis_retry sudo apt-get update -qq; fi
+    - if [ "$TRAVIS_ARCH" = "ppc64le" ]; then 
+          sudo chown -Rvf $USER:$GROUP ~/.cache/pip/wheels; 
+      fi
 
 git:
   depth: 99999


### PR DESCRIPTION
<!-- Specify which issue this PR fixes -->
This pull request fixes #
This PR fixes the support for ppc64le build on travis-ci along with amd64.
<!-- Below provide a summary of what, why, and how  for the changes in this PR -->

### Changes
So for supporting the ppc64le build on travis, i have added below arch and to provide permission for wheeling in .travis.yml.
1) arch:
     - amd64
     - ppc64le
2) in before_install section:
     - if [ "$TRAVIS_ARCH" = "ppc64le" ]; then 
          sudo chown -Rvf $USER:$GROUP ~/.cache/pip/wheels; 
      fi

- [x] I ran tests locally and they passed 
The full test log can be seen here https://travis-ci.com/github/sanjaymsh/duecredit/builds/187596292.
- [ ] If you would like to list yourself as a DueCredit contributor and your name is not mentioned please modify .zenodo.json file.

And i believe it is ready for final review and merge.
Please have a look on this.

Thanks !!
