### PR TITLE
BF: declare strings using \ as r

### DIFF
--- a/duecredit/entries.py
+++ b/duecredit/entries.py
@@ -66,7 +66,7 @@ class BibTeX(DueCreditEntry):
             self._key = key
 
     def _process_rawentry(self):
-        reg = re.match("\s*@(?P<type>\S*)\s*\{\s*(?P<key>\S*)\s*,.*",
+        reg = re.match(r"\s*@(?P<type>\S*)\s*\{\s*(?P<key>\S*)\s*,.*",
                        self._rawentry, flags=re.MULTILINE)
         assert(reg)
         matches = reg.groupdict()

--- a/duecredit/injections/mod_numpy.py
+++ b/duecredit/injections/mod_numpy.py
@@ -18,7 +18,7 @@ max_version = None
 
 
 def inject(injector):
-    injector.add('numpy', None, BibTeX("""
+    injector.add('numpy', None, BibTeX(r"""
     @article{van2011numpy,
         title={The NumPy array: a structure for efficient numerical computation},
         author={Van Der Walt, Stefan and Colbert, S Chris and Varoquaux, Gael},

--- a/duecredit/injections/mod_scipy.py
+++ b/duecredit/injections/mod_scipy.py
@@ -88,7 +88,7 @@ def inject(injector):
                  min_version='0.4.3',
                  tags=['edu'])
 
-    injector.add('scipy.cluster.hierarchy', None, BibTeX("""
+    injector.add('scipy.cluster.hierarchy', None, BibTeX(r"""
     @article{edelbrock1979mixture,
         title={Mixture model tests of hierarchical clustering algorithms:
             the problem of classifying everybody},
@@ -131,7 +131,7 @@ def inject(injector):
                  tags=['edu'])
 
     # Here options for linkage
-    injector.add('scipy.cluster.hierarchy', 'linkage', BibTeX("""
+    injector.add('scipy.cluster.hierarchy', 'linkage', BibTeX(r"""
     @article{ward1963hierarchical,
         title={Hierarchical grouping to optimize an objective function},
         author={Ward Jr, Joe H},

--- a/duecredit/tests/test_io.py
+++ b/duecredit/tests/test_io.py
@@ -375,8 +375,8 @@ def test_text_output_dump_formatting():
     reference_numbers = []
     references = []
     for line in lines:
-        match_citation = re.search('\[([0-9, ]+)\]$', line)
-        match_reference = re.search('^\[([0-9])\]', line)
+        match_citation = re.search(r'\[([0-9, ]+)\]$', line)
+        match_reference = re.search(r'^\[([0-9])\]', line)
         if match_citation:
             citation_numbers.extend(match_citation.group(1).split(', '))
         elif match_reference:


### PR DESCRIPTION
Besides other possible effects,  leads outside code to expose this to the users.  Hopefully I caught all.  `citeproc` 0.5.1 has more to fix