### PR TITLE
Replace pkg_resource with importlib.metadata

### DIFF
--- a/duecredit/versions.py
+++ b/duecredit/versions.py
@@ -9,11 +9,15 @@
 """Module to help maintain a registry of versions for external modules etc
 """
 import sys
-import pkg_resources
 from os import linesep
 from six import string_types
 
 from distutils.version import StrictVersion, LooseVersion
+
+try:
+    from importlib.metadata import version as metadata_version
+except ImportError:
+    from importlib_metadata import version as metadata_version
 
 
 # To depict an unknown version, which can't be compared by mistake etc
@@ -57,15 +61,15 @@ class ExternalVersions(object):
             version = ".".join(str(x) for x in version)
 
         if not version:
-            # Try pkg_resources
+            # Try importlib.metadata
             # module name might be different, and I found no way to
             # deduce it for citeproc which comes from "citeproc-py"
             # distribution
             modname = module.__name__
             try:
-                version = pkg_resources.get_distribution(
+                version = metadata_version(
                     {'citeproc': 'citeproc-py'}.get(modname, modname)
-                ).version
+                )
             except Exception:
                 pass  # oh well - no luck either
 

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,12 @@ setup(
     version=__version__,
     packages=list(find_packages([PACKAGE_ABSPATH], PACKAGE)),
     scripts=[],
-    install_requires=['requests', 'citeproc-py>=0.4', 'six'],
+    install_requires=[
+        'requests',
+        'citeproc-py>=0.4',
+        'six',
+        'importlib-metadata; python_version<"3.8"',
+    ],
     extras_require={
         'tests': [
             'pytest',


### PR DESCRIPTION
This PR replaces the need to add setuptools as a runtime dependency in #175.

### Changes

- [x] I ran tests locally and they passed
