### PR TITLE
Set up intuit auto to automate releases

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,0 +1,15 @@
+{
+    "onlyPublishWithReleaseLabel": true,
+    "baseBranch": "master",
+    "author": "auto <auto@nil>",
+    "noVersionPrefix": true,
+    "plugins": [
+        "git-tag",
+        [
+            "exec",
+            {
+                "afterRelease": "python -m build && twine upload dist/*"
+            }
+        ]
+    ]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Auto-release on PR merge
+
+on:
+  # ATM, this is the closest trigger to a PR merging
+  push:
+    branches:
+      - master
+
+jobs:
+  auto-release:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Download auto
+        run: |
+          auto_download_url="$(curl -fsSL https://api.github.com/repos/intuit/auto/releases/latest | jq -r '.assets[] | select(.name == "auto-linux.gz") | .browser_download_url')"
+          wget -O- "$auto_download_url" | gunzip > ~/auto
+          chmod a+x ~/auto
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '^3.6'
+
+      - name: Install Python dependencies
+        run: python -m pip install build twine
+
+      - name: Create release
+        run: ~/auto shipit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+
+# vim:set sts=2:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,14 +41,3 @@ after_success:
   - coveralls
   - codecov
 
-deploy:
-  provider: pypi
-  distributions: sdist
-  user: yarikoptic
-  password:
-    secure: mTxbioGS+sdfxnJRbAGZCxjWlaGJx+KqXPfYGESKcg6IVaSUM9D4CUhxgHHW88FYSnkmCvwuu57w7AAot9FyG6Q/1q656gluCbEJzfDJerSH1S06HqAEmjSPJvIEG/zwvPIUm3RPc+8j9XtedztM3aVWkqBHAzvUzEnsX1jJpic=
-  on:
-    tags: true
-    branch: master
-    repo: duecredit/duecredit
-    condition: "$TRAVIS_PYTHON_VERSION == 3.8 && $TRAVIS_TAG =~ ^[0-9][.][0-9][.0-9]*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,14 @@
-# Change Log
-
-
-## [0.9.0](https://github.com/duecredit/duecredit/tree/0.9.0) (2021-04-13)
+# [0.9.0](https://github.com/duecredit/duecredit/tree/0.9.0) (2021-04-13)
 
 - Drop support for Python < 3.6
 - Python packaging is reworked, importlib-metadata is added
   as a dependency for python < 3.8
 
-## [0.8.1](https://github.com/duecredit/duecredit/tree/0.8.0) (2021-01-26)
+# [0.8.1](https://github.com/duecredit/duecredit/tree/0.8.0) (2021-01-26)
 
 - Announce lines with unescaped \ as r(aw)
 
-## [0.8.0](https://github.com/duecredit/duecredit/tree/0.8.0) (2020-02-09)
+# [0.8.0](https://github.com/duecredit/duecredit/tree/0.8.0) (2020-02-09)
 
 - Variety of small fixes
 - Added .zenodo.json for more proper citation of duecredit
@@ -20,7 +17,7 @@
 - Address a few deprecation warnings (#146)
 - Provide more informative message whenever using older citeproc without encoding arg
 
-## [0.7.0](https://github.com/duecredit/duecredit/tree/0.7.0) (2019-03-01)
+# [0.7.0](https://github.com/duecredit/duecredit/tree/0.7.0) (2019-03-01)
 
 - Prevent warnings from the injector's `__del__`.
 - InactiveDueCollector in `stub.py` now provides also `active=False`
@@ -31,7 +28,7 @@
   meaningful rendering in BibTex but is present in text rendering.
   `Url` entry also acquired text rendering with prefix `URL: `.
 
-## [0.6.5](https://github.com/duecredit/duecredit/tree/0.6.5) (2019-02-04)
+# [0.6.5](https://github.com/duecredit/duecredit/tree/0.6.5) (2019-02-04)
 
 - Delay import of imports (thanks [Chris Markiewicz (@effigies)](https://github.com/effigies)
   - serves also as a workaround due to inconsistent installation of
@@ -41,30 +38,30 @@
   Thanks [Katrin Leinweber (@katrinleinweber)](https://github.com/katrinleinweber)
   for the contribution
 
-## [0.6.4](https://github.com/duecredit/duecredit/tree/0.6.4) (2018-06-25)
+# [0.6.4](https://github.com/duecredit/duecredit/tree/0.6.4) (2018-06-25)
 
 - Added doi to numpy injection
 - Minor tune-ups to the docs
 
-## [0.6.3](https://github.com/duecredit/duecredit/tree/0.6.3) (2017-08-01)
+# [0.6.3](https://github.com/duecredit/duecredit/tree/0.6.3) (2017-08-01)
 
   Fixed a bug disallowing installation of duecredit in environments with
   crippled/too-basic locale setting.
 
-## [0.6.2](https://github.com/duecredit/duecredit/tree/0.6.2) (2017-06-23)
+# [0.6.2](https://github.com/duecredit/duecredit/tree/0.6.2) (2017-06-23)
 
 - Testing was converted to pytest
 - Various enhancements in supporting python3 and BiBTeX with utf-8
 - New tag 'dataset' to describe datasets
 
-## [0.6.1](https://github.com/duecredit/duecredit/tree/0.6.1) (2016-07-09)
+# [0.6.1](https://github.com/duecredit/duecredit/tree/0.6.1) (2016-07-09)
 [Full Changelog](https://github.com/duecredit/duecredit/compare/0.6.0...0.6.1)
 
 **Merged pull requests:**
 
 - ENH: workaround for pages handling fixed in citeproc post 0.3.0 [\#98](https://github.com/duecredit/duecredit/pull/98) ([yarikoptic](https://github.com/yarikoptic))
 
-## [0.6.0](https://github.com/duecredit/duecredit/tree/0.6.0) (2016-06-17)
+# [0.6.0](https://github.com/duecredit/duecredit/tree/0.6.0) (2016-06-17)
 [Full Changelog](https://github.com/duecredit/duecredit/compare/0.5.0...0.6.0)
 
 **Implemented enhancements:**
@@ -86,7 +83,7 @@
 - enable codecov coverage reports [\#87](https://github.com/duecredit/duecredit/pull/87) ([yarikoptic](https://github.com/yarikoptic))
 - REF,ENH: refactor {BibTeX,Text}Output into Output class with subclasses [\#86](https://github.com/duecredit/duecredit/pull/86) ([mvdoc](https://github.com/mvdoc))
 
-## [0.5.0](https://github.com/duecredit/duecredit/tree/0.5.0) (2016-05-11)
+# [0.5.0](https://github.com/duecredit/duecredit/tree/0.5.0) (2016-05-11)
 [Full Changelog](https://github.com/duecredit/duecredit/compare/0.4.8...0.5.0)
 
 **Fixed bugs:**
@@ -104,7 +101,7 @@
 - enable testing under python 3.5 on travis [\#79](https://github.com/duecredit/duecredit/pull/79) ([yarikoptic](https://github.com/yarikoptic))
 - ENH: appveyor configuration \(based on shablona's\) based on mix of conda and pip [\#70](https://github.com/duecredit/duecredit/pull/70) ([yarikoptic](https://github.com/yarikoptic))
 
-## [0.4.8](https://github.com/duecredit/duecredit/tree/0.4.8) (2016-05-04)
+# [0.4.8](https://github.com/duecredit/duecredit/tree/0.4.8) (2016-05-04)
 [Full Changelog](https://github.com/duecredit/duecredit/compare/0.4.7...0.4.8)
 
 **Closed issues:**
@@ -117,10 +114,10 @@
 - BF: change request command to make it work with zenodo too [\#76](https://github.com/duecredit/duecredit/pull/76) ([mvdoc](https://github.com/mvdoc))
 - DOC: Show that user can also enter BibTeX entries [\#75](https://github.com/duecredit/duecredit/pull/75) ([mvdoc](https://github.com/mvdoc))
 
-## [0.4.7](https://github.com/duecredit/duecredit/tree/0.4.7) (2016-04-21)
+# [0.4.7](https://github.com/duecredit/duecredit/tree/0.4.7) (2016-04-21)
 [Full Changelog](https://github.com/duecredit/duecredit/compare/0.4.6...0.4.7)
 
-## [0.4.6](https://github.com/duecredit/duecredit/tree/0.4.6) (2016-04-19)
+# [0.4.6](https://github.com/duecredit/duecredit/tree/0.4.6) (2016-04-19)
 [Full Changelog](https://github.com/duecredit/duecredit/compare/0.4.5...0.4.6)
 
 **Fixed bugs:**
@@ -133,17 +130,17 @@
 - Use HTTPS for GitHub URL [\#67](https://github.com/duecredit/duecredit/pull/67) ([jwilk](https://github.com/jwilk))
 - Fix typos [\#66](https://github.com/duecredit/duecredit/pull/66) ([jwilk](https://github.com/jwilk))
 
-## [0.4.5](https://github.com/duecredit/duecredit/tree/0.4.5) (2015-12-03)
+# [0.4.5](https://github.com/duecredit/duecredit/tree/0.4.5) (2015-12-03)
 [Full Changelog](https://github.com/duecredit/duecredit/compare/0.4.4...0.4.5)
 
 **Merged pull requests:**
 
 - Make duecredit import and stub more robust to failures with e.g. import of lxml [\#65](https://github.com/duecredit/duecredit/pull/65) ([yarikoptic](https://github.com/yarikoptic))
 
-## [0.4.4](https://github.com/duecredit/duecredit/tree/0.4.4) (2015-11-08)
+# [0.4.4](https://github.com/duecredit/duecredit/tree/0.4.4) (2015-11-08)
 [Full Changelog](https://github.com/duecredit/duecredit/compare/0.4.3...0.4.4)
 
-## [0.4.3](https://github.com/duecredit/duecredit/tree/0.4.3) (2015-09-28)
+# [0.4.3](https://github.com/duecredit/duecredit/tree/0.4.3) (2015-09-28)
 [Full Changelog](https://github.com/duecredit/duecredit/compare/0.4.2...0.4.3)
 
 **Implemented enhancements:**
@@ -159,7 +156,7 @@
 - ENH: versions -- provide dumps, keys, \_\_contains\_\_ [\#57](https://github.com/duecredit/duecredit/pull/57) ([yarikoptic](https://github.com/yarikoptic))
 - ENH: Two more module level injections [\#56](https://github.com/duecredit/duecredit/pull/56) ([yarikoptic](https://github.com/yarikoptic))
 
-## [0.4.2](https://github.com/duecredit/duecredit/tree/0.4.2) (2015-09-03)
+# [0.4.2](https://github.com/duecredit/duecredit/tree/0.4.2) (2015-09-03)
 [Full Changelog](https://github.com/duecredit/duecredit/compare/0.4.1...0.4.2)
 
 **Closed issues:**
@@ -172,10 +169,10 @@
 - Overhaul conditions -- "and" logic \(all must be met\) + allow to access attributes of the arguments [\#50](https://github.com/duecredit/duecredit/pull/50) ([yarikoptic](https://github.com/yarikoptic))
 - BF: Fix get\_text\_rendering when Citation is passed with Doi [\#46](https://github.com/duecredit/duecredit/pull/46) ([mvdoc](https://github.com/mvdoc))
 
-## [0.4.1](https://github.com/duecredit/duecredit/tree/0.4.1) (2015-08-27)
+# [0.4.1](https://github.com/duecredit/duecredit/tree/0.4.1) (2015-08-27)
 [Full Changelog](https://github.com/duecredit/duecredit/compare/0.4.0...0.4.1)
 
-## [0.4.0](https://github.com/duecredit/duecredit/tree/0.4.0) (2015-08-21)
+# [0.4.0](https://github.com/duecredit/duecredit/tree/0.4.0) (2015-08-21)
 [Full Changelog](https://github.com/duecredit/duecredit/compare/0.3.0...0.4.0)
 
 **Fixed bugs:**
@@ -195,7 +192,7 @@
 - REF: text output, divide "model" from "view" [\#41](https://github.com/duecredit/duecredit/pull/41) ([mvdoc](https://github.com/mvdoc))
 - RF to provide \_\_main\_\_ so we could do   python -m duecredit  existing script [\#39](https://github.com/duecredit/duecredit/pull/39) ([yarikoptic](https://github.com/yarikoptic))
 
-## [0.3.0](https://github.com/duecredit/duecredit/tree/0.3.0) (2015-08-05)
+# [0.3.0](https://github.com/duecredit/duecredit/tree/0.3.0) (2015-08-05)
 [Full Changelog](https://github.com/duecredit/duecredit/compare/0.2.2...0.3.0)
 
 **Implemented enhancements:**
@@ -221,13 +218,13 @@
 - BF: give correct ref numbers for citations [\#24](https://github.com/duecredit/duecredit/pull/24) ([mvdoc](https://github.com/mvdoc))
 - Fix typo in README.md [\#21](https://github.com/duecredit/duecredit/pull/21) ([lesteve](https://github.com/lesteve))
 
-## [0.2.2](https://github.com/duecredit/duecredit/tree/0.2.2) (2015-07-27)
+# [0.2.2](https://github.com/duecredit/duecredit/tree/0.2.2) (2015-07-27)
 [Full Changelog](https://github.com/duecredit/duecredit/compare/0.2.1...0.2.2)
 
-## [0.2.1](https://github.com/duecredit/duecredit/tree/0.2.1) (2015-07-27)
+# [0.2.1](https://github.com/duecredit/duecredit/tree/0.2.1) (2015-07-27)
 [Full Changelog](https://github.com/duecredit/duecredit/compare/0.2.0...0.2.1)
 
-## [0.2.0](https://github.com/duecredit/duecredit/tree/0.2.0) (2015-07-27)
+# [0.2.0](https://github.com/duecredit/duecredit/tree/0.2.0) (2015-07-27)
 [Full Changelog](https://github.com/duecredit/duecredit/compare/0.1.1...0.2.0)
 
 **Closed issues:**
@@ -247,10 +244,10 @@
 - WiP NF: core to implement "injection" of duecredit entries into other modules [\#10](https://github.com/duecredit/duecredit/pull/10) ([yarikoptic](https://github.com/yarikoptic))
 - coveralls call should be without any args, also test installation now [\#9](https://github.com/duecredit/duecredit/pull/9) ([yarikoptic](https://github.com/yarikoptic))
 
-## [0.1.1](https://github.com/duecredit/duecredit/tree/0.1.1) (2015-06-26)
+# [0.1.1](https://github.com/duecredit/duecredit/tree/0.1.1) (2015-06-26)
 [Full Changelog](https://github.com/duecredit/duecredit/compare/0.1.0...0.1.1)
 
-## [0.1.0](https://github.com/duecredit/duecredit/tree/0.1.0) (2015-06-21)
+# [0.1.0](https://github.com/duecredit/duecredit/tree/0.1.0) (2015-06-21)
 [Full Changelog](https://github.com/duecredit/duecredit/compare/0.0.0...0.1.0)
 
 **Closed issues:**
@@ -261,7 +258,7 @@
 
 - Stub tests pass [\#1](https://github.com/duecredit/duecredit/pull/1) ([mvdoc](https://github.com/mvdoc))
 
-## [0.0.0](https://github.com/duecredit/duecredit/tree/0.0.0) (2013-12-06)
+# [0.0.0](https://github.com/duecredit/duecredit/tree/0.0.0) (2013-12-06)
 
 
 \* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*


### PR DESCRIPTION
This PR needs to be accompanied by the following changes:

- [x] Create the necessary labels for `auto` by running `GH_TOKEN=... auto create-labels` in a copy of this repository containing `.autorc`
- [x] A GitHub release must be created for the most recent version of duecredit
- [x] An auth token for uploading assets for the `duecredit` project to PyPI must be saved as a secret named "`PYPI_TOKEN`"
- [x] .travis.yml should get "release to pypi" stripped away (in this PR)
- [x] Modify `CHANGELOG.md` so its sectioning matches the format used by `auto`; specifically, eliminate the part above the topmost version section and remove a `#` from all remaining headers