### PR TITLE
RF: remove remaining usage of SIX, and thus move away fully from Python 2

### DIFF
--- a/duecredit/cmdline/helpers.py
+++ b/duecredit/cmdline/helpers.py
@@ -88,7 +88,7 @@ def parser_add_common_opt(parser, opt, names=None, **kwargs):
     else:
         parser.add_argument(*names, **opt_kwargs)
 
-class RegexpType(object):
+class RegexpType:
     """Factory for creating regular expression types for argparse
 
     DEPRECATED AFAIK -- now things are in the config file...

--- a/duecredit/collector.py
+++ b/duecredit/collector.py
@@ -12,8 +12,6 @@ import os
 import sys
 from functools import wraps
 
-from six import iteritems, itervalues
-
 from .config import DUECREDIT_FILE
 from .entries import DueCreditEntry
 from .stub import InactiveDueCreditCollector
@@ -27,7 +25,7 @@ lgr = logging.getLogger('duecredit.collector')
 
 CitationKey = namedtuple('CitationKey', ['path', 'entry_key'])
 
-class Citation(object):
+class Citation:
     """Encapsulates citations and information on their use"""
 
     def __init__(self, entry, description=None, path=None, version=None,
@@ -174,7 +172,7 @@ class Citation(object):
         self._entry = newentry
 
 
-class DueCreditCollector(object):
+class DueCreditCollector:
     """Collect the references
 
     The mighty beast which will might become later a proxy on the way to
@@ -274,7 +272,7 @@ class DueCreditCollector(object):
                 # package_loaded = sys.modules.get(package)
                 # if package_loaded:
                 #     # find the citation for that module
-                #     for citation in itervalues(self.citations):
+                #     for citation in self.citations.values():
                 #         if citation.package == package \
                 #                 and not citation.version:
                 version = external_versions[package]
@@ -285,7 +283,7 @@ class DueCreditCollector(object):
     def _citations_fromentrykey(self):
         """Return a dictionary with the current citations indexed by the entry key"""
         citations_key = dict()
-        for (path, entry_key), citation in iteritems(self.citations):
+        for (path, entry_key), citation in self.citations.items():
             if entry_key not in citations_key:
                 citations_key[entry_key] = citation
 
@@ -296,7 +294,7 @@ class DueCreditCollector(object):
     def _args_match_conditions(conditions, *fargs, **fkwargs):
         """Helper to identify when to trigger citation given parameters to the function call
         """
-        for (argpos, kwarg), values in iteritems(conditions):
+        for (argpos, kwarg), values in conditions.items():
             # main logic -- assess default and if get to the next one if
             # given argument is not present
             if not ((len(fargs) > argpos) or (kwarg in fkwargs)):
@@ -369,7 +367,7 @@ class DueCreditCollector(object):
 
         Conditional based on the state of the object
 
-        >>> class Citeable(object):
+        >>> class Citeable:
         ...     def __init__(self, param=None):
         ...         self.param = param
         ...     @due.dcite('XXX00', description="The same good old relief",
@@ -441,7 +439,7 @@ class DueCreditCollector(object):
 
 
 # TODO: redo heavily -- got very messy
-class CollectorSummary(object):
+class CollectorSummary:
     """A helper which would take care about exporting citations upon its Death
     """
     def __init__(self, collector, outputs="stdout,pickle", fn=DUECREDIT_FILE):

--- a/duecredit/dueswitch.py
+++ b/duecredit/dueswitch.py
@@ -52,7 +52,7 @@ def _get_active_due():
     return due_
 
 
-class DueSwitch(object):
+class DueSwitch:
     """Adapter between two types of collectors -- Inactive and Active
 
     Once activated though, cannot be fully deactivated since it would inject

--- a/duecredit/entries.py
+++ b/duecredit/entries.py
@@ -8,13 +8,12 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 import re
-from six import PY2
 
 import logging
 lgr = logging.getLogger('duecredit.entries')
 
 
-class DueCreditEntry(object):
+class DueCreditEntry:
     def __init__(self, rawentry, key=None):
         self._rawentry = rawentry
         self._key = key or rawentry.lower()
@@ -34,10 +33,7 @@ class DueCreditEntry(object):
 
     @property
     def rawentry(self):
-        if PY2:
-            return unicode(self._rawentry)
-        else:
-            return self._rawentry
+        return self._rawentry
 
     def _process_rawentry(self):
         pass

--- a/duecredit/injections/injector.py
+++ b/duecredit/injections/injector.py
@@ -20,7 +20,6 @@ from functools import wraps
 import logging
 from ..log import lgr
 
-from six import iteritems
 import builtins as __builtin__
 
 
@@ -63,7 +62,7 @@ def find_object(mod, path):
 # stay friendly to anyone else who might decorate __import__ as well
 _very_orig_import = __builtin__.__import__
 
-class DueCreditInjector(object):
+class DueCreditInjector:
     """Takes care about "injecting" duecredit references into 3rd party modules upon their import
 
     First entries to be "injected" need to be add'ed to the instance.
@@ -197,7 +196,7 @@ class DueCreditInjector(object):
         # go through the known entries and register them within the collector, and
         # decorate corresponding methods
         # There could be multiple records per module
-        for obj_path, obj_entry_records in iteritems(self._entry_records[mod_name]):
+        for obj_path, obj_entry_records in self._entry_records[mod_name].items():
             parent, obj_name = None, None
             if obj_path:
                 # so we point to an object within the mod

--- a/duecredit/io.py
+++ b/duecredit/io.py
@@ -20,7 +20,6 @@ import copy
 from os.path import dirname, exists
 import pickle
 import tempfile
-from six import PY2, itervalues, iteritems
 import warnings
 import platform
 from time import sleep
@@ -49,8 +48,6 @@ def import_doi(doi, sleep=0.5, retries=10):
     if exists(cached):
         with open(cached) as f:
             doi = f.read()
-            if PY2:
-                return doi.decode('utf-8')
             return doi
 
     # else -- fetch it
@@ -78,10 +75,7 @@ def import_doi(doi, sleep=0.5, retries=10):
         if not exists(cache_dir):
             os.makedirs(cache_dir)
         with open(cached, 'w') as f:
-            if PY2:
-                f.write(bibtex.encode('utf-8'))
-            else:
-                f.write(bibtex)
+            f.write(bibtex)
     return bibtex
 
 
@@ -94,7 +88,7 @@ def _is_contained(toppath, subpath):
         return subpath.startswith(toppath + '.')
 
 
-class Output(object):
+class Output:
     """A generic class for setting up citations that then will be outputted
     differently (e.g., Bibtex, Text, etc.)"""
     def __init__(self, fd, collector):
@@ -115,7 +109,7 @@ class Output(object):
         if tags != {'*'}:
             # Filter out citations based on tags
             citations = dict((k, c)
-                             for k, c in iteritems(citations)
+                             for k, c in citations.items()
                              if tags.intersection(c.tags))
 
         packages = defaultdict(list)
@@ -124,7 +118,7 @@ class Output(object):
 
         # store the citations according to their path and divide them into
         # the right level
-        for (path, entry_key), citation in iteritems(citations):
+        for (path, entry_key), citation in citations.items():
             if ':' in path:
                 objects[path].append(citation)
             elif '.' in path:
@@ -351,7 +345,7 @@ def format_bibtex(bibtex_entry, style='harvard1'):
     return biblio_out # if biblio_out else str(bibtex_entry)
 
 # TODO: harmonize order of arguments
-class PickleOutput(object):
+class PickleOutput:
     def __init__(self, collector, fn=DUECREDIT_FILE):
         self.collector = collector
         self.fn = fn

--- a/duecredit/log.py
+++ b/duecredit/log.py
@@ -33,7 +33,7 @@ def mbasename(s):
         base = basename(dirname(s)) + '.' + base
     return base
 
-class TraceBack(object):
+class TraceBack:
     """Customized traceback to be included in debug messages
     """
 
@@ -138,7 +138,7 @@ class ColorFormatter(logging.Formatter):
         return logging.Formatter.format(self, record)
 
 
-class LoggerHelper(object):
+class LoggerHelper:
     """Helper to establish and control a Logger"""
 
     def __init__(self, name='duecredit'):

--- a/duecredit/parsers.py
+++ b/duecredit/parsers.py
@@ -1,5 +1,3 @@
-import re
-
 def extract_references_from_rst(rst):
     # for now will be very simple, just trying to separate
     # then up until the end or another section starting

--- a/duecredit/stub.py
+++ b/duecredit/stub.py
@@ -27,7 +27,7 @@ License:    BSD-2
 __version__ = '0.0.9'
 
 
-class InactiveDueCreditCollector(object):
+class InactiveDueCreditCollector:
     """Just a stub at the Collector which would not do anything"""
     def _donothing(self, *args, **kwargs):
         """Perform no good and no bad"""

--- a/duecredit/tests/mod/imported.py
+++ b/duecredit/tests/mod/imported.py
@@ -3,16 +3,16 @@ def testfunc1(arg1, kwarg1=None):
     return "testfunc1: %s, %s" % (arg1, kwarg1)
 
 
-class TestClass1(object):
+class TestClass1:
     """wrong custom docstring"""
     def testmeth1(self, arg1, kwarg1=None):
         """custom docstring"""
         return "TestClass1.testmeth1: %s, %s" % (arg1, kwarg1)
 
 
-class TestClass12(object):
+class TestClass12:
     """wrong custom docstring"""
-    class Embed(object):
+    class Embed:
         """wrong custom docstring"""
         def testmeth1(self, arg1, kwarg1=None):
             """custom docstring"""

--- a/duecredit/tests/mod/submod.py
+++ b/duecredit/tests/mod/submod.py
@@ -6,6 +6,6 @@ def testfunc(arg1, kwarg1=None):
     return "testfunc: %s, %s" % (arg1, kwarg1)
 
 
-class TestClass(object):
+class TestClass:
     def testmeth(self, arg1, kwarg1=None):
         return "testmeth: %s, %s" % (arg1, kwarg1)

--- a/duecredit/tests/test__main__.py
+++ b/duecredit/tests/test__main__.py
@@ -10,7 +10,7 @@
 import sys
 import pytest
 
-from six.moves import StringIO
+from io import StringIO
 
 from .. import __main__, __version__
 from .. import due

--- a/duecredit/tests/test_api.py
+++ b/duecredit/tests/test_api.py
@@ -86,7 +86,7 @@ def test_api(collector_class):
     def purpose_of_life():
         return None
 
-    class Child(object):
+    class Child:
         # Conception process is usually way too easy to be referenced
         def __init__(self):
             pass

--- a/duecredit/tests/test_cmdline.py
+++ b/duecredit/tests/test_cmdline.py
@@ -8,8 +8,8 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 import sys
+from io import StringIO
 
-from six.moves import StringIO
 import pytest
 
 from .. import __version__

--- a/duecredit/tests/test_collector.py
+++ b/duecredit/tests/test_collector.py
@@ -112,7 +112,7 @@ def test_dcite_method():
             assert kwarg2 == 1
             return "load"
 
-        class SomeClass(object):
+        class SomeClass:
             @due.dcite("XXX0", path='someclass:method')
             def method(self, arg1, kwarg2="blah"):
                 """docstring"""
@@ -149,7 +149,7 @@ def test_dcite_method():
             # And we explicitly stated that module need to be cited
             assert citation.cite_module
 
-        class SomeClass2(object):
+        class SomeClass2:
             # Used to test for classes that are not instantiated
             @due.dcite("XXX0", path="some.module.without.method")
             def method2(self, arg1, kwarg2="blah"):
@@ -249,7 +249,7 @@ def test_dcite_match_conditions_method():
     due = DueCreditCollector()
     due.add(BibTeX(_sample_bibtex))
 
-    class Citeable(object):
+    class Citeable:
         def __init__(self, param=None):
             self.param = param
 

--- a/duecredit/tests/test_entries.py
+++ b/duecredit/tests/test_entries.py
@@ -13,8 +13,7 @@ import pickle
 import os
 import pytest
 
-from six.moves import StringIO
-from six import text_type
+from io import StringIO
 
 import duecredit.io
 from ..collector import DueCreditCollector, Citation

--- a/duecredit/tests/test_injections.py
+++ b/duecredit/tests/test_injections.py
@@ -39,7 +39,7 @@ class TestActiveInjector:
         self.injector = DueCreditInjector(collector=self.due)
         self.injector.activate(retrospect=False)  # numpy might be already loaded...
 
-    def teardown(self):
+    def teardown_method(self):
         lgr.log(5, "Tearing down after a TestActiveInjector test")
         # gc might not pick up inj after some tests complete
         # so we will always deactivate explicitly

--- a/duecredit/tests/test_injections.py
+++ b/duecredit/tests/test_injections.py
@@ -11,12 +11,7 @@ import gc
 import sys
 import pytest
 
-from six import viewvalues, PY2
-
-if PY2:
-    import __builtin__
-else:
-    import builtins as __builtin__
+import builtins as __builtin__
 _orig__import__ = __builtin__.__import__
 
 from duecredit.collector import DueCreditCollector
@@ -36,7 +31,7 @@ from logging import getLogger
 lgr = getLogger('duecredit.tests.injector')
 
 
-class TestActiveInjector(object):
+class TestActiveInjector:
     def setup_method(self):
         lgr.log(5, "Setting up for a TestActiveInjector test")
         self._cleanup_modules()
@@ -88,7 +83,7 @@ class TestActiveInjector(object):
         assert len(self.due.citations) == 1
 
         # TODO: there must be a cleaner way to get first value
-        citation = list(viewvalues(self.due.citations))[0]
+        citation = list(self.due.citations.values())[0]
         # TODO: ATM we don't allow versioning of the submodules -- we should
         # assert_equal(citation.version, '0.5')
         # ATM it will be the duecredit's version
@@ -135,7 +130,7 @@ class TestActiveInjector(object):
         assert len(self.due.citations) == 2
 
         # TODO: there must be a cleaner way to get first value
-        citation = list(viewvalues(self.due.citations))[0]
+        citation = list(self.due.citations.values())[0]
         # TODO: ATM we don't allow versioning of the submodules -- we should
         # assert_equal(citation.version, '0.5')
         # ATM it will be the duecredit's version

--- a/duecredit/tests/test_io.py
+++ b/duecredit/tests/test_io.py
@@ -12,9 +12,7 @@ import re
 import pickle
 import os
 import pytest
-
-from six.moves import StringIO
-from six import text_type
+from io import StringIO
 
 import duecredit.io
 from ..collector import DueCreditCollector, Citation
@@ -33,14 +31,14 @@ try:
     def test_import_doi():
         doi_good = '10.1038/nrd842'
         kw = dict(sleep=0.00001, retries=2)
-        assert isinstance(import_doi(doi_good, **kw), text_type)
+        assert isinstance(import_doi(doi_good, **kw), str)
 
         doi_bad = 'fasljfdldaksj'
         with pytest.raises(ValueError):
             import_doi(doi_bad, **kw)
 
         doi_zenodo = '10.5281/zenodo.50186'
-        assert isinstance(import_doi(doi_zenodo, **kw), text_type)
+        assert isinstance(import_doi(doi_zenodo, **kw), str)
 
 except ImportError:
     # no vcr, and that is in 2015!

--- a/duecredit/tests/test_utils.py
+++ b/duecredit/tests/test_utils.py
@@ -14,7 +14,7 @@ from ..utils import is_interactive
 
 
 def test_is_interactive_crippled_stdout(monkeypatch):
-    class MockedOut(object):
+    class MockedOut:
         """the one which has no isatty
         """
         def write(self, *args, **kwargs):

--- a/duecredit/tests/test_versions.py
+++ b/duecredit/tests/test_versions.py
@@ -8,17 +8,15 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 from os import linesep
+
 import pytest
 
 from ..version import __version__
 from ..versions import ExternalVersions, StrictVersion
 
-from six import PY3
-
-if PY3:
-    # just to ease testing
-    def cmp(a, b):
-        return (a > b) - (a < b)
+# just to ease testing
+def cmp(a, b):
+    return (a > b) - (a < b)
 
 
 def test_external_versions_basic():

--- a/duecredit/utils.py
+++ b/duecredit/utils.py
@@ -13,9 +13,11 @@ import os
 import logging
 import sys
 import platform
+import shutil
+import stat
 import tempfile
+import time
 
-from six import binary_type
 from os.path import exists, join as opj, isabs, expandvars, expanduser, abspath
 
 from os.path import realpath
@@ -141,7 +143,7 @@ def rmtemp(f, *args, **kwargs):
                     os.unlink(f)
                 except OSError as e:
                     if i < 9:
-                        sleep(0.1)
+                        time.sleep(0.1)
                         continue
                     else:
                         raise

--- a/duecredit/versions.py
+++ b/duecredit/versions.py
@@ -10,7 +10,6 @@
 """
 import sys
 from os import linesep
-from six import string_types
 
 from distutils.version import StrictVersion, LooseVersion
 
@@ -34,7 +33,7 @@ class UnknownVersion:
         raise TypeError("UNKNOWN version is not comparable")
 
 
-class ExternalVersions(object):
+class ExternalVersions:
     """Helper to figure out/use versions of the external modules.
 
     It maintains a dictionary of `distuil.version.StrictVersion`s to make
@@ -85,7 +84,7 @@ class ExternalVersions(object):
     def __getitem__(self, module):
         # when ran straight in its source code -- fails to discover nipy's version.. TODO
         #if module == 'nipy':
-        if not isinstance(module, string_types):
+        if not isinstance(module, str):
             modname = module.__name__
         else:
             modname = module

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,6 @@ setup(
     install_requires=[
         'requests',
         'citeproc-py>=0.4',
-        'six',
         'importlib-metadata; python_version<"3.8"',
     ],
     extras_require={


### PR DESCRIPTION
https://wiki.debian.org/Python3-six-removal

https://github.com/duecredit/duecredit/commit/523f54742b8d38ced03ad3d37ef3a061f8c6e544)


(ok i i did not read /CONTRIBUTING.md but I'm catching up...)

### Changes

- [ ] I ran tests locally and they passed
- [ ] If you would like to list yourself as a DueCredit contributor and your name is not mentioned please modify .zenodo.json file.

