### PR TITLE
RF: annotate entries.py, fix a string format in test

### DIFF
--- a/duecredit/collector.py
+++ b/duecredit/collector.py
@@ -95,10 +95,6 @@ class Citation:
     def path(self):
         return self._path
 
-    @property
-    def cite_module(self):
-        return self._cite_module
-
     @path.setter
     def path(self, path):
         # TODO: verify value, if we are not up for it -- just make _path public
@@ -111,6 +107,10 @@ class Citation:
     @property
     def description(self):
         return self._description
+
+    @property
+    def cite_module(self):
+        return self._cite_module
 
     @property
     def cites_module(self):

--- a/duecredit/entries.py
+++ b/duecredit/entries.py
@@ -8,51 +8,55 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 import re
+from typing import Optional
 
 import logging
 lgr = logging.getLogger('duecredit.entries')
 
 
 class DueCreditEntry:
-    def __init__(self, rawentry, key=None):
+    _key : str
+
+    def __init__(self, rawentry:str, key: Optional[str] = None) -> None:
         self._rawentry = rawentry
         self._key = key or rawentry.lower()
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, DueCreditEntry):
+            raise NotImplemented
         return (
             (self._rawentry == other._rawentry) and
             (self._key == other._key)
         )
 
-    def get_key(self):
+    def get_key(self) -> str:
         return self._key
 
     @property
-    def key(self):
+    def key(self) -> str:
         return self.get_key()
 
     @property
-    def rawentry(self):
+    def rawentry(self) -> str:
         return self._rawentry
 
-    def _process_rawentry(self):
+    def _process_rawentry(self) -> None:
         pass
 
-    def __repr__(self):
-        args = [repr(self._rawentry),
+    def __repr__(self) -> str:
+        argl = [repr(self._rawentry),
                 "key={0}".format(repr(self._key))]
-        args = ", ".join(args)
+        args = ", ".join(argl)
         return self.__class__.__name__ + '({0})'.format(args)
 
-    def format(self):
+    def format(self) -> str:
         # TODO: return nice formatting of the entry
         return str(self._rawentry)
 
 
 class BibTeX(DueCreditEntry):
-    def __init__(self, bibtex, key=None):
+    def __init__(self, bibtex: str, key: Optional[str] = None) -> None:
         super(BibTeX, self).__init__(bibtex.strip())
-        self._key = None
         self._reference = None
         self._process_rawentry()
         if key is not None:
@@ -61,7 +65,7 @@ class BibTeX(DueCreditEntry):
                       self._key, key)
             self._key = key
 
-    def _process_rawentry(self):
+    def _process_rawentry(self) -> None:
         reg = re.match(r"\s*@(?P<type>\S*)\s*\{\s*(?P<key>\S*)\s*,.*",
                        self._rawentry, flags=re.MULTILINE)
         assert(reg)
@@ -78,13 +82,13 @@ class Text(DueCreditEntry):
 class Doi(DueCreditEntry):
 
     @property
-    def doi(self):
+    def doi(self) -> str:
         return self._rawentry
 
 
 class Url(DueCreditEntry):
 
     @property
-    def url(self):
+    def url(self) -> str:
         return self._rawentry
 

--- a/duecredit/stub.py
+++ b/duecredit/stub.py
@@ -62,8 +62,8 @@ except Exception as e:
         logging.getLogger("duecredit").error(
             "Failed to import duecredit due to %s" % str(e))
     # Initiate due stub
-    due = InactiveDueCreditCollector()
-    BibTeX = Doi = Url = Text = _donothing_func
+    due = InactiveDueCreditCollector()  # type: ignore
+    BibTeX = Doi = Url = Text = _donothing_func  # type: ignore
 
 # Emacs mode definitions
 # Local Variables:

--- a/duecredit/tests/test_io.py
+++ b/duecredit/tests/test_io.py
@@ -438,7 +438,7 @@ def test_bibtex_output():
     value = strio.getvalue()
     value_ = sorted(value.strip().split('\n'))
     bibtex = sorted((_sample_bibtex.strip() + _sample_bibtex2.rstrip()).split('\n'))
-    assert value_ == bibtex, 'Value was {0}'.format(value_, bibtex)
+    assert value_ == bibtex, 'Value was {0} instead of {1}'.format(value_, bibtex)
 
     # assert_equal(value_, bibtex,
     #              msg='Value was {0}'.format(value_, bibtex))


### PR DESCRIPTION
This is just an example on how/why add annotations, they enable a new kind of linting with `mypy`; they also make it easier for newcomers to contribute to bigger projects;

To do it more logicaly, I would first need to spend more time on `citeproc-py`, but I see there's globaly much more to do on this other project. (but I cheated with `sudo touch /usr/lib/python3/dist-packages/citeproc/py.typed`)

----

this includes a workaround to a mypy bug: https://github.com/python/mypy/issues/1465