### PR TITLE
Better coverage config

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,0 @@
-[run]
-branch = True
-source = duecredit
-include = 
-  duecredit/*
-  examples/*
-

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,8 @@ envlist = flake8,py3,typing
 #,flake8
 
 [testenv]
-commands = py.test
+commands = pytest duecredit
 deps = -r{toxinidir}/requirements.txt
-
-[testenv:cover]
-commands = coverage run --source duecredit -m py.test
 
 [testenv:flake8]
 commands = flake8 {posargs}
@@ -34,9 +31,22 @@ include = duecredit
 exclude = .tox,.venv,venv-debug,build,dist,doc,git/ext/
 
 [pytest]
-addopts = --tb=short --durations=10
+addopts =
+    --cov=duecredit
+    # Explicitly setting the path to the coverage config file is necessary due
+    # to some tests spawning subprocesses with changed working directories.
+    --cov-config=tox.ini
+    --tb=short
+    --durations=10
 filterwarnings =
     # TODO: review/address all warnings
     # error
-    ignore:--include is ignored because --source is set (include-ignored):DeprecationWarning:coverage
 
+[coverage:run]
+branch = True
+parallel = True
+
+[coverage:paths]
+source =
+    duecredit
+    .tox/**/site-packages/duecredit


### PR DESCRIPTION
- Moves the coverage configuration from `.coveragerc` to `tox.ini`, next to the rest of the testing configuration

- Corrects the coverage configuration by removing the `include` key (ignored when `source` is set), thereby eliminating a warning

- Eliminates the `cover` testenv in favor of always using `pytest-cov` in the default testenv