### PR TITLE
Don't `pip install codecov`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel
-        pip install -q codecov
         python setup.py --help # just to trigger generation of .version
         pip install --upgrade flake8 pytest
         pip install ".[tests]"


### PR DESCRIPTION
Pip-installing codecov is superfluous when using the codecov action.