### PR TITLE
Remove use of importlib.metadata backport

### DIFF
--- a/duecredit/versions.py
+++ b/duecredit/versions.py
@@ -11,14 +11,10 @@ from __future__ import annotations
 """Module to help maintain a registry of versions for external modules etc
 """
 from distutils.version import LooseVersion, StrictVersion
+from importlib.metadata import version as metadata_version
 from os import linesep
 import sys
 from typing import Any
-
-try:
-    from importlib.metadata import version as metadata_version
-except ImportError:
-    from importlib_metadata import version as metadata_version  # type: ignore
 
 
 # To depict an unknown version, which can't be compared by mistake etc

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,6 @@ setup(
     install_requires=[
         "requests",
         "citeproc-py>=0.4",
-        'importlib-metadata; python_version<"3.8"',
     ],
     extras_require={"tests": ["pytest", "pytest-cov", "vcrpy", "contextlib2"]},
     include_package_data=True,


### PR DESCRIPTION
This is unnecessary now that duecredit requires Python 3.8+.