### PR TITLE
Log to stderr not stdout by default

### DIFF
--- a/duecredit/log.py
+++ b/duecredit/log.py
@@ -195,7 +195,7 @@ class LoggerHelper:
         ----------
         target: string, optional
           Which log target to request logger for
-        logtarget: { 'stdout', 'stderr', str }, optional
+        logtarget: { 'stderr', 'stdout', str }, optional
           Where to direct the logs.  stdout and stderr stand for standard streams.
           Any other string is considered a filename.  Multiple entries could be
           specified comma-separated
@@ -205,7 +205,7 @@ class LoggerHelper:
         logging.Logger
         """
         # By default mimic previously talkative behavior
-        logtarget_ = self._get_environ("LOGTARGET", logtarget or "stdout")
+        logtarget_ = self._get_environ("LOGTARGET", logtarget or "stderr")
         assert type(logtarget_) is str
 
         # Allow for multiple handlers being specified, comma-separated


### PR DESCRIPTION
That could prevent interaction with downstream libraries which import duecredit first thing in their life cycle.  And since then they might rely on stdout to be used for actually useful content, we better not to pollute it.

Underlying trigger for such a fix:

- https://github.com/dandi/dandi-cli/issues/1441

Release is needed as we have not released for awhile and downstream needs 3.12 compatibility etc