### PR TITLE
remove last reference to contextlib2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
         "packaging",
         "requests",
     ],
-    extras_require={"tests": ["pytest", "pytest-cov", "vcrpy", "contextlib2"]},
+    extras_require={"tests": ["pytest", "pytest-cov", "vcrpy"]},
     include_package_data=True,
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
This was maybe usefull until Python 3.3