### PR TITLE
Travis is not used anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # duecredit
 
 
-[![Build Status](https://travis-ci.org/duecredit/duecredit.svg?branch=master)](https://travis-ci.org/duecredit/duecredit)
 [![Coverage Status](https://coveralls.io/repos/duecredit/duecredit/badge.svg)](https://coveralls.io/r/duecredit/duecredit)
 [![DOI](https://zenodo.org/badge/DOI/110.5281/zenodo.3376260.svg)](https://doi.org/10.5281/zenodo.3376260)
 [![PyPI version fury.io](https://badge.fury.io/py/duecredit.svg)](https://pypi.python.org/pypi/duecredit/)


### PR DESCRIPTION
### Changes

Remove obsolete badge.

- [ ] I ran tests locally and they passed
- [ ] If you would like to list yourself as a DueCredit contributor and your name is not mentioned please modify .zenodo.json file.