### PR TITLE
Start applying ruff/flake8-comprehensions rules

### DIFF
--- a/duecredit/io.py
+++ b/duecredit/io.py
@@ -202,7 +202,7 @@ class TextOutput(Output):
         pmo.update(objects)
 
         # get all the paths
-        paths = sorted(list(pmo))
+        paths = sorted(pmo)
         # get all the entry_keys in order
         entry_keys = [c.entry.key for p in paths for c in pmo[p]]
         # make a dictionary entry_key -> citation_nr
@@ -400,7 +400,7 @@ class BibTeXOutput(Output):
         pmo.update(objects)
 
         # get all the paths
-        paths = sorted(list(pmo))
+        paths = sorted(pmo)
 
         entries = []
         for path in paths:


### PR DESCRIPTION
### Changes

C414 Unnecessary `list()` call within `sorted()`

- [ ] I ran tests locally and they passed
- [ ] If you would like to list yourself as a DueCredit contributor and your name is not mentioned please modify .zenodo.json file.
