### PR TITLE
Apply ruff/Pylint Warning rules

### DIFF
--- a/duecredit/injections/injector.py
+++ b/duecredit/injections/injector.py
@@ -189,7 +189,7 @@ class DueCreditInjector:
                 inj_mod_name_full, fromlist=["duecredit.injections"]
             )
         except Exception as e:
-            if os.environ.get("DUECREDIT_ALLOW_FAIL", False):
+            if os.environ.get("DUECREDIT_ALLOW_FAIL", None):
                 raise
             raise RuntimeError("Failed to import {}: {!r}".format(inj_mod_name, e))
         # TODO: process min/max_versions etc

--- a/duecredit/log.py
+++ b/duecredit/log.py
@@ -112,7 +112,7 @@ class ColorFormatter(logging.Formatter):
         msg = self.formatter_msg(self._get_format(log_name), self.use_color)
         self._tb = (
             TraceBack(collide=os.environ.get("DUECREDIT_LOGTRACEBACK", "") == "collide")
-            if os.environ.get("DUECREDIT_LOGTRACEBACK", False)
+            if os.environ.get("DUECREDIT_LOGTRACEBACK", None)
             else None
         )
         logging.Formatter.__init__(self, msg)

--- a/duecredit/tests/test_api.py
+++ b/duecredit/tests/test_api.py
@@ -216,10 +216,10 @@ def test_noincorrect_import_if_no_lxml_numpy(
         assert ret == 0  # but we must not fail overall regardless
 
     if (
-        os.environ.get("DUECREDIT_ENABLE", False) and on_windows
+        os.environ.get("DUECREDIT_ENABLE", None) and on_windows
     ):  # TODO this test fails on windows
         pytest.xfail("Fails for some reason on Windows")
-    elif os.environ.get("DUECREDIT_ENABLE", False):  # we enabled duecredit
+    elif os.environ.get("DUECREDIT_ENABLE", None):  # we enabled duecredit
         if (
             os.environ.get("DUECREDIT_REPORT_TAGS", None) == "*"
             and kwargs.get("script")

--- a/duecredit/utils.py
+++ b/duecredit/utils.py
@@ -214,7 +214,7 @@ def never_fail(f):
                 % (f, e)
             )
 
-    if os.environ.get("DUECREDIT_ALLOW_FAIL", False):
+    if os.environ.get("DUECREDIT_ALLOW_FAIL", None):
         return f
     else:
         return wrapped_func


### PR DESCRIPTION
### Changes

PLW1508 Invalid type for environment variable default; expected `str` or `None`

- [ ] I ran tests locally and they passed
- [ ] If you would like to list yourself as a DueCredit contributor and your name is not mentioned please modify .zenodo.json file.
