### PR TITLE
Apply ruff/pyupgrade rules UP031/UP032: .format instead of % + prefer f-strings

### DIFF
--- a/duecredit/__main__.py
+++ b/duecredit/__main__.py
@@ -18,15 +18,14 @@ from .log import lgr
 def usage(outfile, executable=sys.argv[0]):
     if "__main__.py" in executable:
         # That was -m duecredit way to launch
-        executable = "%s -m duecredit" % sys.executable
+        executable = f"{sys.executable} -m duecredit"
     outfile.write(
-        """Usage: %s [OPTIONS] <file> [ARGS]
+        f"""Usage: {executable} [OPTIONS] <file> [ARGS]
 
 Meta-options:
 --help                Display this help then exit.
 --version             Output version information then exit.
 """
-        % executable
     )
 
 
@@ -56,8 +55,8 @@ def main(argv=None):
         # probably needs to hook in somehow into commands/options available
         # under cmdline/
     except getopt.error as msg:
-        sys.stderr.write("{}: {}\n".format(sys.argv[0], msg))
-        sys.stderr.write("Try `%s --help' for more information\n" % sys.argv[0])
+        sys.stderr.write(f"{sys.argv[0]}: {msg}\n")
+        sys.stderr.write(f"Try `{sys.argv[0]} --help' for more information\n")
         sys.exit(1)
 
     # and now we need to execute target script "manually"
@@ -68,7 +67,7 @@ def main(argv=None):
             sys.exit(0)
 
         if opt == "--version":
-            sys.stdout.write("duecredit %s\n" % __version__)
+            sys.stdout.write(f"duecredit {__version__}\n")
             sys.exit(0)
 
     sys.argv = prog_argv
@@ -90,7 +89,7 @@ def main(argv=None):
         runctx(code, globs, globs)
         # TODO: see if we could hide our presence from the final tracebacks if execution fails
     except OSError as err:
-        lgr.error("Cannot run file {!r} because: {}".format(sys.argv[0], err))
+        lgr.error(f"Cannot run file {sys.argv[0]!r} because: {err}")
         sys.exit(1)
     except SystemExit:
         pass

--- a/duecredit/cmdline/cmd_summary.py
+++ b/duecredit/cmdline/cmd_summary.py
@@ -52,7 +52,7 @@ def run(args: argparse.Namespace) -> int:
     from ..io import PickleOutput
 
     if not os.path.exists(args.filename):
-        lgr.debug("File {} doesn't exist.  No summary available".format(args.filename))
+        lgr.debug(f"File {args.filename} doesn't exist.  No summary available")
         return 1
 
     due = PickleOutput.load(args.filename)
@@ -64,6 +64,6 @@ def run(args: argparse.Namespace) -> int:
     elif args.format == "bibtex":
         out = BibTeXOutput(sys.stdout, due)
     else:
-        raise ValueError("unknown to treat %s" % args.format)
+        raise ValueError(f"unknown to treat {args.format}")
     out.dump()
     return 0

--- a/duecredit/cmdline/helpers.py
+++ b/duecredit/cmdline/helpers.py
@@ -36,7 +36,7 @@ class HelpAction(argparse.Action):
                 import subprocess
 
                 subprocess.check_call(
-                    "man %s 2> /dev/null" % parser.prog.replace(" ", "-"),
+                    "man {} 2> /dev/null".format(parser.prog.replace(" ", "-")),
                     shell=True,
                 )
                 sys.exit(0)
@@ -44,7 +44,7 @@ class HelpAction(argparse.Action):
                 # ...but silently fall back if it doesn't work
                 pass
         if option_string == "-h":
-            helpstr = "%s\n%s" % (
+            helpstr = "{}\n{}".format(
                 parser.format_usage(),
                 "Use '--help' to get more comprehensive information.",
             )
@@ -65,7 +65,7 @@ class HelpAction(argparse.Action):
             usagestr = re.split(r"\n\n[A-Z]+", helpstr, maxsplit=1)[0]
             usage_length = len(usagestr)
             usagestr = re.subn(r"\s+", " ", usagestr.replace("\n", " "))[0]
-            helpstr = "{}\n{}".format(usagestr, helpstr[usage_length:])
+            helpstr = f"{usagestr}\n{helpstr[usage_length:]}"
         print(helpstr)
         sys.exit(0)
 

--- a/duecredit/cmdline/main.py
+++ b/duecredit/cmdline/main.py
@@ -197,5 +197,5 @@ def main(args: Any = None) -> None:
         try:
             args.func(args)
         except Exception as exc:
-            lgr.error(f"{str(exc)} ({exc.__class__.__name__})")
+            lgr.error(f"{exc} ({exc.__class__.__name__})")
             sys.exit(1)

--- a/duecredit/cmdline/main.py
+++ b/duecredit/cmdline/main.py
@@ -143,7 +143,7 @@ def setup_parser() -> argparse.ArgumentParser:
 
         # configure 'run' function for this command
         subparser.set_defaults(
-            func=subcmdmod.run, logger=logging.getLogger("duecredit.%s" % cmd)
+            func=subcmdmod.run, logger=logging.getLogger(f"duecredit.{cmd}")
         )
         # store short description for later
         sdescr = getattr(
@@ -155,8 +155,7 @@ def setup_parser() -> argparse.ArgumentParser:
     cmd_summary = []
     for cd in cmd_short_description:
         cmd_summary.append(
-            "%s\n%s\n\n"
-            % (
+            "{}\n{}\n\n".format(
                 cd[0],
                 textwrap.fill(
                     cd[1],
@@ -166,15 +165,14 @@ def setup_parser() -> argparse.ArgumentParser:
                 ),
             )
         )
-    parser.description = "%s\n%s\n\n%s" % (
+    parser.description = "{}\n{}\n\n{}".format(
         parser.description,
         "\n".join(cmd_summary),
         textwrap.fill(
-            """\
+            f"""\
     Detailed usage information for individual commands is
     available via command-specific help options, i.e.:
-    %s <command> --help"""
-            % sys.argv[0],
+    {sys.argv[0]} <command> --help""",
             75,
             initial_indent="",
             subsequent_indent="",
@@ -199,5 +197,5 @@ def main(args: Any = None) -> None:
         try:
             args.func(args)
         except Exception as exc:
-            lgr.error("{} ({})".format(str(exc), exc.__class__.__name__))
+            lgr.error(f"{str(exc)} ({exc.__class__.__name__})")
             sys.exit(1)

--- a/duecredit/collector.py
+++ b/duecredit/collector.py
@@ -458,7 +458,7 @@ class DueCreditCollector:
 
     @never_fail
     def __str__(self) -> str:
-        return self.__class__.__name__ + f" {len(self._entries):d} entries, {len(self.citations):d} citations"
+        return f"{self.__class__.__name__} {len(self._entries)} entries, {len(self.citations)} citations"
 
 
 # TODO: redo heavily -- got very messy

--- a/duecredit/collector.py
+++ b/duecredit/collector.py
@@ -239,7 +239,7 @@ class DueCreditCollector:
             raise ValueError("Must be a string")
 
     def _load_bib(self, src: str) -> None:
-        lgr.debug("Loading %s" % src)
+        lgr.debug(f"Loading {src}")
 
     # # TODO: figure out what would be the optimal use for the __call__
     # def __call__(self, *args, **kwargs):
@@ -405,7 +405,7 @@ class DueCreditCollector:
                 # deduce path from the actual function which was decorated
                 # TODO: must include class name  but can't !!!???
                 modname = func.__module__
-                path = kwargs["path"] = "{}:{}".format(modname, func.__name__)
+                path = kwargs["path"] = f"{modname}:{func.__name__}"
             else:
                 # TODO: we indeed need to separate path logic outside
                 modname = path.split(":", 1)[0]
@@ -420,7 +420,7 @@ class DueCreditCollector:
             # see e.g.
             # http://stackoverflow.com/questions/961048/get-class-that-defined-method
             lgr.debug(
-                "Decorating func {} within module {}".format(func.__name__, modname)
+                f"Decorating func {func.__name__} within module {modname}"
             )
             # TODO: unittest for all the __version__ madness
 
@@ -434,7 +434,7 @@ class DueCreditCollector:
                     ):
                         self.cite(*args, **kwargs)
                 except Exception as e:
-                    lgr.warning("Failed to cite due to {}".format(e))
+                    lgr.warning(f"Failed to cite due to {e}")
                 return func(*fargs, **fkwargs)
 
             cite_wrapper.__duecredited__ = func
@@ -458,9 +458,7 @@ class DueCreditCollector:
 
     @never_fail
     def __str__(self) -> str:
-        return self.__class__.__name__ + " {:d} entries, {:d} citations".format(
-            len(self._entries), len(self.citations)
-        )
+        return self.__class__.__name__ + f" {len(self._entries):d} entries, {len(self.citations):d} citations"
 
 
 # TODO: redo heavily -- got very messy

--- a/duecredit/dueswitch.py
+++ b/duecredit/dueswitch.py
@@ -139,7 +139,7 @@ class DueSwitch:
             try:
                 self.__prepare_exit_and_injections()
             except Exception as e:
-                lgr.error(f"Failed to prepare injections etc: {str(e)}")
+                lgr.error(f"Failed to prepare injections etc: {e}")
             finally:
                 self.__activations_done = True
 

--- a/duecredit/dueswitch.py
+++ b/duecredit/dueswitch.py
@@ -55,8 +55,8 @@ def _get_active_due() -> DueCreditCollector | InactiveDueCreditCollector:
             due_ = load_due(DUECREDIT_FILE)
         except Exception:
             lgr.warning(
-                "Failed to load previously collected %s. "
-                "DueCredit will not be active for this session." % DUECREDIT_FILE
+                f"Failed to load previously collected {DUECREDIT_FILE}. "
+                "DueCredit will not be active for this session."
             )
             return _get_inactive_due()
     else:
@@ -79,7 +79,7 @@ class DueSwitch:
         if not (inactive and active):
             raise ValueError(
                 "Both inactive and active collectors should be provided. "
-                "Got active=%r, inactive=%r" % (active, inactive)
+                f"Got active={active!r}, inactive={inactive!r}"
             )
         self.activate(activate)
 
@@ -139,7 +139,7 @@ class DueSwitch:
             try:
                 self.__prepare_exit_and_injections()
             except Exception as e:
-                lgr.error("Failed to prepare injections etc: %s" % str(e))
+                lgr.error(f"Failed to prepare injections etc: {str(e)}")
             finally:
                 self.__activations_done = True
 

--- a/duecredit/injections/injector.py
+++ b/duecredit/injections/injector.py
@@ -160,7 +160,7 @@ class DueCreditInjector:
             self._entry_records[modulename][obj] = []
         obj_entries = self._entry_records[modulename][obj]
         if "path" not in kwargs:
-            kwargs["path"] = modulename + ((":%s" % obj) if obj else "")
+            kwargs["path"] = modulename + ((f":{obj}") if obj else "")
         obj_entries.append(
             {
                 "entry": entry,
@@ -191,7 +191,7 @@ class DueCreditInjector:
         except Exception as e:
             if os.environ.get("DUECREDIT_ALLOW_FAIL", None):
                 raise
-            raise RuntimeError("Failed to import {}: {!r}".format(inj_mod_name, e))
+            raise RuntimeError(f"Failed to import {inj_mod_name}: {e!r}")
         # TODO: process min/max_versions etc
         assert hasattr(inj_mod, "inject")
         lgr.log(3, "Calling injector of %s", inj_mod_name_full)
@@ -227,7 +227,7 @@ class DueCreditInjector:
         try:
             mod = sys.modules[mod_name]
         except KeyError:
-            lgr.warning("Failed to access module %s among sys.modules" % mod_name)
+            lgr.warning(f"Failed to access module {mod_name} among sys.modules")
             return
 
         # go through the known entries and register them within the collector, and
@@ -241,7 +241,7 @@ class DueCreditInjector:
                     parent, obj_name, obj = find_object(mod, obj_path)
                 except (KeyError, AttributeError) as e:
                     lgr.warning(
-                        "Could not find {} in module {}: {}".format(obj_path, mod, e)
+                        f"Could not find {obj_path} in module {mod}: {e}"
                     )
                     continue
 

--- a/duecredit/io.py
+++ b/duecredit/io.py
@@ -301,7 +301,7 @@ def format_bibtex(bibtex_entry: BibTeX, style: str = "harvard1") -> str:
     except ImportError as e:
         raise RuntimeError(
             "For formatted output we need citeproc and all of its dependencies "
-            f"(such as lxml) but there is a problem while importing citeproc: {str(e)}"
+            f"(such as lxml) but there is a problem while importing citeproc: {e}"
         )
     decode_exceptions: tuple[type[Exception], ...]
     try:

--- a/duecredit/io.py
+++ b/duecredit/io.py
@@ -268,7 +268,7 @@ def get_bibtex_rendering(entry: DueCreditEntry) -> BibTeX:
     elif isinstance(entry, BibTeX):
         return entry
     else:
-        raise ValueError("Have no clue how to get bibtex out of %s" % entry)
+        raise ValueError(f"Have no clue how to get bibtex out of {entry}")
 
 
 def condition_bibtex(bibtex: str) -> bytes:
@@ -301,8 +301,7 @@ def format_bibtex(bibtex_entry: BibTeX, style: str = "harvard1") -> str:
     except ImportError as e:
         raise RuntimeError(
             "For formatted output we need citeproc and all of its dependencies "
-            "(such as lxml) but there is a problem while importing citeproc: %s"
-            % str(e)
+            f"(such as lxml) but there is a problem while importing citeproc: {str(e)}"
         )
     decode_exceptions: tuple[type[Exception], ...]
     try:
@@ -330,7 +329,7 @@ def format_bibtex(bibtex_entry: BibTeX, style: str = "harvard1") -> str:
                 # we should be able to provide encoding argument
                 bib_source = cpBibTeX(fname, encoding="utf-8")
         except Exception as e:
-            msg = "Failed to process BibTeX file {}: {}.".format(fname, e)
+            msg = f"Failed to process BibTeX file {fname}: {e}."
             if "unexpected keyword argument" in str(e):
                 citeproc_version = external_versions["citeproc"]
                 if isinstance(citeproc_version, Version) and citeproc_version < Version(
@@ -341,7 +340,7 @@ def format_bibtex(bibtex_entry: BibTeX, style: str = "harvard1") -> str:
             else:
                 err = str(e)
             lgr.error(msg)
-            return "ERRORED: %s" % err
+            return f"ERRORED: {err}"
         finally:
             # return warnings back
             warnings.filters = old_filters

--- a/duecredit/log.py
+++ b/duecredit/log.py
@@ -66,10 +66,10 @@ class TraceBack:
         entries_out = [entries[0]]
         for entry in entries[1:]:
             if entry[0] == entries_out[-1][0]:
-                entries_out[-1][1] += ",%s" % entry[1]
+                entries_out[-1][1] += f",{entry[1]}"
             else:
                 entries_out.append(entry)
-        sftb = ">".join(["{}:{}".format(mbasename(x[0]), x[1]) for x in entries_out])
+        sftb = ">".join([f"{mbasename(x[0])}:{x[1]}" for x in entries_out])
         if self.__collide:
             # lets remove part which is common with previous invocation
             prev_next = sftb
@@ -163,7 +163,7 @@ class LoggerHelper:
     def _get_environ(
         self, var: str, default: str | None | bool = None
     ) -> str | None | bool:
-        return os.environ.get(self.name.upper() + "_%s" % var.upper(), default)
+        return os.environ.get(self.name.upper() + f"_{var.upper()}", default)
 
     def set_level(self, level: str | None = None, default: str = "WARNING") -> None:
         """Helper to set loglevel for an arbitrary logger

--- a/duecredit/log.py
+++ b/duecredit/log.py
@@ -91,7 +91,7 @@ class ColorFormatter(logging.Formatter):
     BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE = range(8)
 
     RESET_SEQ = "\033[0m"
-    COLOR_SEQ = "\033[1;%dm"
+    COLOR_SEQ = "\033[1;{}m"
     BOLD_SEQ = "\033[1m"
 
     COLORS = {
@@ -143,7 +143,7 @@ class ColorFormatter(logging.Formatter):
         if self.use_color and levelname in self.COLORS:
             fore_color = 30 + self.COLORS[levelname]
             levelname_color = (
-                self.COLOR_SEQ % fore_color + "%-7s" % levelname + self.RESET_SEQ
+                self.COLOR_SEQ.format(fore_color) + f"{levelname:<7}" + self.RESET_SEQ
             )
             record.levelname = levelname_color
         record.msg = record.msg.replace("\n", "\n| ")

--- a/duecredit/stub.py
+++ b/duecredit/stub.py
@@ -68,7 +68,7 @@ except Exception as e:
         import logging
 
         logging.getLogger("duecredit").error(
-            "Failed to import duecredit due to %s" % str(e)
+            f"Failed to import duecredit due to {str(e)}"
         )
     # Initiate due stub
     due = InactiveDueCreditCollector()  # type: ignore

--- a/duecredit/stub.py
+++ b/duecredit/stub.py
@@ -68,7 +68,7 @@ except Exception as e:
         import logging
 
         logging.getLogger("duecredit").error(
-            f"Failed to import duecredit due to {str(e)}"
+            f"Failed to import duecredit due to {e}"
         )
     # Initiate due stub
     due = InactiveDueCreditCollector()  # type: ignore

--- a/duecredit/tests/mod/imported.py
+++ b/duecredit/tests/mod/imported.py
@@ -3,7 +3,7 @@ from typing import Any
 
 def testfunc1(arg1: Any, kwarg1: Any = None) -> str:
     """custom docstring"""
-    return "testfunc1: {}, {}".format(arg1, kwarg1)
+    return f"testfunc1: {arg1}, {kwarg1}"
 
 
 class TestClass1:
@@ -11,7 +11,7 @@ class TestClass1:
 
     def testmeth1(self, arg1: Any, kwarg1: Any = None) -> str:
         """custom docstring"""
-        return "TestClass1.testmeth1: {}, {}".format(arg1, kwarg1)
+        return f"TestClass1.testmeth1: {arg1}, {kwarg1}"
 
 
 class TestClass12:
@@ -22,4 +22,4 @@ class TestClass12:
 
         def testmeth1(self, arg1: Any, kwarg1: Any = None) -> str:
             """custom docstring"""
-            return "TestClass12.Embed.testmeth1: {}, {}".format(arg1, kwarg1)
+            return f"TestClass12.Embed.testmeth1: {arg1}, {kwarg1}"

--- a/duecredit/tests/mod/submod.py
+++ b/duecredit/tests/mod/submod.py
@@ -4,9 +4,9 @@ from typing import Any
 
 def testfunc(arg1: Any, kwarg1: Any = None) -> str:
     """testfunc docstring"""
-    return "testfunc: {}, {}".format(arg1, kwarg1)
+    return f"testfunc: {arg1}, {kwarg1}"
 
 
 class TestClass:
     def testmeth(self, arg1: Any, kwarg1: Any = None) -> str:
-        return "testmeth: {}, {}".format(arg1, kwarg1)
+        return f"testmeth: {arg1}, {kwarg1}"

--- a/duecredit/tests/test__main__.py
+++ b/duecredit/tests/test__main__.py
@@ -28,7 +28,7 @@ def test_main_help(monkeypatch: MonkeyPatch) -> None:
 
     pytest.raises(SystemExit, __main__.main, ["__main__.py", "--help"])
     assert fakestdout.getvalue().startswith(
-        "Usage: %s -m duecredit [OPTIONS] <file> [ARGS]\n" % sys.executable
+        f"Usage: {sys.executable} -m duecredit [OPTIONS] <file> [ARGS]\n"
     )
 
 
@@ -38,7 +38,7 @@ def test_main_version(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr(sys, "stdout", fakestdout)
 
     pytest.raises(SystemExit, __main__.main, ["__main__.py", "--version"])
-    assert fakestdout.getvalue().rstrip() == "duecredit %s" % __version__
+    assert fakestdout.getvalue().rstrip() == f"duecredit {__version__}"
 
 
 def test_main_run_a_script(tmpdir: py.path.local, monkeypatch: MonkeyPatch) -> None:

--- a/duecredit/tests/test_cmdline.py
+++ b/duecredit/tests/test_cmdline.py
@@ -39,7 +39,7 @@ def test_main_version(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr(sys, fakeout, fakestdout)
 
     pytest.raises(SystemExit, main.main, ["--version"])
-    assert (fakestdout.getvalue()).split("\n")[0] == "duecredit %s" % __version__
+    assert (fakestdout.getvalue()).split("\n")[0] == f"duecredit {__version__}"
 
 
 # smoke test the cmd_summary

--- a/duecredit/tests/test_collector.py
+++ b/duecredit/tests/test_collector.py
@@ -258,7 +258,7 @@ def test_dcite_match_conditions_function() -> None:
     def method(arg1: str, kwarg2: str = "blah") -> str:
         """docstring"""
         assert arg1 == "magical"
-        return "load %s" % kwarg2
+        return f"load {kwarg2}"
 
     _test_dcite_match_conditions(due, method, "callable")
 
@@ -285,7 +285,7 @@ def test_dcite_match_conditions_method() -> None:
         def method(self, arg1: str, kwarg2: str = "blah") -> str:
             """docstring"""
             assert arg1 == "magical"
-            return "load %s" % kwarg2
+            return f"load {kwarg2}"
 
     citeable = Citeable(param="paramvalue")
     _test_dcite_match_conditions(due, citeable.method, "obj.callable")

--- a/duecredit/tests/test_injections.py
+++ b/duecredit/tests/test_injections.py
@@ -65,7 +65,7 @@ class TestActiveInjector:
             "duecredit.tests.mod",
             func,
             Doi("1.2.3.4"),
-            description="Testing %s" % func,
+            description=f"Testing {func}",
             min_version="0.1",
             max_version="1.0",
             tags=["implementation", "very custom"],
@@ -92,7 +92,7 @@ class TestActiveInjector:
         exec('ret = %s(None, "somevalue")' % (func_call or func), globals_, locals_)
         # TODO: awkwardly 'ret' is not found in the scope while running pytest
         # under python3.4, although present in locals()... WTF?
-        assert locals_["ret"] == "%s: None, somevalue" % func
+        assert locals_["ret"] == f"{func}: None, somevalue"
         assert len(self.due._entries) == 1
         assert len(self.due.citations) == 1
 
@@ -112,7 +112,7 @@ class TestActiveInjector:
             "duecredit.tests.mod",
             func,
             Doi("1.2.3.4"),
-            description="Testing %s" % func,
+            description=f"Testing {func}",
             min_version="0.1",
             max_version="1.0",
             tags=["implementation", "very custom"],
@@ -122,7 +122,7 @@ class TestActiveInjector:
             "duecredit.tests.mod",
             func,
             Doi("1.2.3.5"),
-            description="Testing %s" % func,
+            description=f"Testing {func}",
             min_version="0.1",
             max_version="1.0",
             tags=["implementation", "very custom"],
@@ -149,7 +149,7 @@ class TestActiveInjector:
         exec('ret = %s(None, "somevalue")' % (func_call or func), globals_, locals_)
         # TODO: awkwardly 'ret' is not found in the scope while running pytest
         # under python3.4, although present in locals()... WTF?
-        assert locals_["ret"] == "%s: None, somevalue" % func
+        assert locals_["ret"] == f"{func}: None, somevalue"
         assert len(self.due._entries) == 2
         assert len(self.due.citations) == 2
 
@@ -193,7 +193,7 @@ class TestActiveInjector:
             # We do have injections for scipy
             import scipy  # noqa: F401
         except ImportError as e:
-            pytest.skip("scipy was not found: {}".format(e))
+            pytest.skip(f"scipy was not found: {e}")
 
     def test_import_mvpa2_suite(self) -> None:
         if not _have_mvpa2:

--- a/duecredit/tests/test_io.py
+++ b/duecredit/tests/test_io.py
@@ -294,9 +294,9 @@ def test_text_output() -> None:
     strio = StringIO()
     TextOutput(strio, collector).dump(tags=["*"])
     value = strio.getvalue()
-    assert "0 packages cited" in value, "value was %s" % value
-    assert "0 modules cited" in value, "value was %s" % value
-    assert "0 functions cited" in value, "value was %s" % value
+    assert "0 packages cited" in value, f"value was {value}"
+    assert "0 modules cited" in value, f"value was {value}"
+    assert "0 functions cited" in value, f"value was {value}"
 
     # but it should be cited if cite_module=True
     collector = DueCreditCollector()
@@ -305,9 +305,9 @@ def test_text_output() -> None:
     strio = StringIO()
     TextOutput(strio, collector).dump(tags=["*"])
     value = strio.getvalue()
-    assert "1 package cited" in value, "value was %s" % value
-    assert "0 modules cited" in value, "value was %s" % value
-    assert "0 functions cited" in value, "value was %s" % value
+    assert "1 package cited" in value, f"value was {value}"
+    assert "0 modules cited" in value, f"value was {value}"
+    assert "0 functions cited" in value, f"value was {value}"
 
     # in this case, we should be citing the package since we are also citing a
     # submodule
@@ -318,10 +318,10 @@ def test_text_output() -> None:
     strio = StringIO()
     TextOutput(strio, collector).dump(tags=["*"])
     value = strio.getvalue()
-    assert "1 package cited" in value, "value was %s" % value
-    assert "1 module cited" in value, "value was %s" % value
-    assert "0 functions cited" in value, "value was %s" % value
-    assert "Halchenko, Y.O." in value, "value was %s" % value
+    assert "1 package cited" in value, f"value was {value}"
+    assert "1 module cited" in value, f"value was {value}"
+    assert "0 functions cited" in value, f"value was {value}"
+    assert "Halchenko, Y.O." in value, f"value was {value}"
     assert value.strip().endswith("Frontiers in Neuroinformatics, 6(22).")
 
     # in this case, we should be citing the package since we are also citing a
@@ -334,12 +334,12 @@ def test_text_output() -> None:
     strio = StringIO()
     TextOutput(strio, collector).dump(tags=["*"])
     value = strio.getvalue()
-    assert "1 package cited" in value, "value was %s" % value
-    assert "1 module cited" in value, "value was %s" % value
-    assert "0 functions cited" in value, "value was %s" % value
-    assert "Halchenko, Y.O." in value, "value was %s" % value
-    assert "[1, 2]" in value, "value was %s" % value
-    assert "[3]" not in value, "value was %s" % value
+    assert "1 package cited" in value, f"value was {value}"
+    assert "1 module cited" in value, f"value was {value}"
+    assert "0 functions cited" in value, f"value was {value}"
+    assert "Halchenko, Y.O." in value, f"value was {value}"
+    assert "[1, 2]" in value, f"value was {value}"
+    assert "[3]" not in value, f"value was {value}"
 
 
 def test_text_output_dump_formatting() -> None:
@@ -539,9 +539,9 @@ def _generate_sample_bibtex() -> str:
         ("year", year),
     ]
 
-    sample_bibtex = "@ARTICLE{%s,\n" % key
+    sample_bibtex = f"@ARTICLE{{{key},\n"
     for string, value in elements:
-        sample_bibtex += "{}={{{}}},\n".format(string, value)
+        sample_bibtex += f"{string}={{{value}}},\n"
     sample_bibtex += "}"
     return sample_bibtex
 

--- a/duecredit/tests/test_utils.py
+++ b/duecredit/tests/test_utils.py
@@ -29,10 +29,10 @@ def test_is_interactive_crippled_stdout(monkeypatch: MonkeyPatch) -> None:
             return True
 
     for inout in ("in", "out", "err"):
-        monkeypatch.setattr(sys, "std%s" % inout, MockedOut())
+        monkeypatch.setattr(sys, f"std{inout}", MockedOut())
         assert not is_interactive()
 
     # just for paranoids
     for inout in ("in", "out", "err"):
-        monkeypatch.setattr(sys, "std%s" % inout, MockedIsaTTY())
+        monkeypatch.setattr(sys, f"std{inout}", MockedIsaTTY())
     assert is_interactive()

--- a/duecredit/tests/test_versions.py
+++ b/duecredit/tests/test_versions.py
@@ -36,7 +36,7 @@ def test_external_versions_basic():
     version_str = (
         str(ev["duecredit"]) if isinstance(ev["duecredit"], Version) else __version__
     )
-    assert ev.dumps() == "Versions: duecredit=%s" % version_str
+    assert ev.dumps() == f"Versions: duecredit={version_str}"
 
     # For non-existing one we get None
     assert ev["duecreditnonexisting"] is None
@@ -74,11 +74,11 @@ def test_external_versions_unknown() -> None:
 
 def _test_external(ev, modname: str) -> None:
     try:
-        exec("import %s" % modname, globals(), locals())
+        exec(f"import {modname}", globals(), locals())
     except ImportError:
         modname = pytest.importorskip(modname)
     except Exception as e:
-        pytest.skip("External {} fails to import: {}".format(modname, e))
+        pytest.skip(f"External {modname} fails to import: {e}")
     assert ev[modname] is not ev.UNKNOWN
     assert ev[modname] > Version("0.0.1")
     assert Version("1000000.0") > ev[modname]  # unlikely in our lifetimes

--- a/duecredit/utils.py
+++ b/duecredit/utils.py
@@ -145,9 +145,9 @@ def rmtemp(f: str, *args: Any, **kwargs: Any) -> None:
     """
     if not os.environ.get("DATALAD_TESTS_KEEPTEMP"):
         if not os.path.lexists(f):
-            lgr.debug("Path %s does not exist, so can't be removed" % f)
+            lgr.debug(f"Path {f} does not exist, so can't be removed")
             return
-        lgr.log(5, "Removing temp file: %s" % f)
+        lgr.log(5, f"Removing temp file: {f}")
         # Can also be a directory
         if os.path.isdir(f):
             rmtree(f, *args, **kwargs)
@@ -163,7 +163,7 @@ def rmtemp(f: str, *args: Any, **kwargs: Any) -> None:
                         raise
                 break
     else:
-        lgr.info("Keeping temp file: %s" % f)
+        lgr.info(f"Keeping temp file: {f}")
 
 
 #
@@ -209,9 +209,8 @@ def never_fail(f):
             return f(*args, **kwargs)
         except Exception as e:
             lgr.warning(
-                "DueCredit internal failure while running %s: %r. "
+                f"DueCredit internal failure while running {f}: {e!r}. "
                 "Please report to developers at https://github.com/duecredit/duecredit/issues"
-                % (f, e)
             )
 
     if os.environ.get("DUECREDIT_ALLOW_FAIL", None):

--- a/duecredit/versions.py
+++ b/duecredit/versions.py
@@ -132,8 +132,8 @@ class ExternalVersions:
         preamble: str, optional
           What preamble to the listing to use
         """
-        items = ["{}={}".format(k, self._versions[k]) for k in sorted(self._versions)]
-        out = "%s" % preamble
+        items = [f"{k}={self._versions[k]}" for k in sorted(self._versions)]
+        out = f"{preamble}"
         if indent:
             indent_ = " " if indent is True else indent
             out += (linesep + indent_).join([""] + items) + linesep

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ except OSError:
             exec(code, locals(), globals())
     else:
         __version__ = "0.0.0.dev"
-print("Version: %s" % __version__)
+print(f"Version: {__version__}")
 
 with open("README.md", encoding="utf-8") as f:
     README = f.read()


### PR DESCRIPTION
### Changes

UP031 Use format specifiers instead of percent format
UP032 Use f-string instead of `format` call

- [ ] I ran tests locally and they passed
- [ ] If you would like to list yourself as a DueCredit contributor and your name is not mentioned please modify .zenodo.json file.
