### PR TITLE
Apply ruff/pycodestyle rule E713

### DIFF
--- a/duecredit/collector.py
+++ b/duecredit/collector.py
@@ -130,7 +130,7 @@ class Citation:
     def cites_module(self) -> bool | None:
         if not self.path:
             return None
-        return not (":" in self.path)
+        return ":" not in self.path
 
     @property
     def module(self) -> str | None:
@@ -318,7 +318,7 @@ class DueCreditCollector:
             # main logic -- assess default and if get to the next one if
             # given argument is not present
             if not ((len(fargs) > argpos) or (kwarg in fkwargs)):
-                if not ("DC_DEFAULT" in values):
+                if "DC_DEFAULT" not in values:
                     # if value was specified but not provided and not default
                     # conditions are not satisfied
                     return False
@@ -339,7 +339,7 @@ class DueCreditCollector:
                     value = getattr(value, attr)
 
             # Value is present but not matching
-            if not (value in values):
+            if value not in values:
                 return False
 
         # if checks passed -- we must have matched conditions

--- a/duecredit/dueswitch.py
+++ b/duecredit/dueswitch.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 def _get_duecredit_enable() -> bool:
     env_enable = os.environ.get("DUECREDIT_ENABLE", "no")
-    if not env_enable.lower() in ("0", "1", "yes", "no", "true", "false"):
+    if env_enable.lower() not in ("0", "1", "yes", "no", "true", "false"):
         lgr.warning(
             "Misunderstood value %s for DUECREDIT_ENABLE. "
             "Use 'yes' or 'no', or '0' or '1'"


### PR DESCRIPTION
### Changes

E713 Test for membership should be `not in`

- [ ] I ran tests locally and they passed
- [ ] If you would like to list yourself as a DueCredit contributor and your name is not mentioned please modify .zenodo.json file.
