### PR TITLE
Add ruff to pre-commit config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
         python -m pip install --upgrade pip wheel
         pip install --upgrade pytest
         pip install ".[tests]"
-    
+
     - name: Install extra dependencies
       run: |
         if [ -n "${{ matrix.extra-pip }}" ]; then

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,8 +9,8 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
-  - repo: https://github.com/psf/black
-    rev: 23.11.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 25.1.0
     hooks:
       - id: black
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,12 @@ repos:
           - flake8-builtins
           - flake8-unused-arguments
 
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.2
+    hooks:
+      - id: ruff
+        args: ["--fix", "--show-fixes"]
+
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:

--- a/duecredit/cmdline/__init__.py
+++ b/duecredit/cmdline/__init__.py
@@ -6,8 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""
-"""
+""" """
 
 __docformat__ = "restructuredtext"
 

--- a/duecredit/cmdline/cmd_summary.py
+++ b/duecredit/cmdline/cmd_summary.py
@@ -6,9 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Spit out the summary of the citations which were collected.
-
-"""
+"""Spit out the summary of the citations which were collected."""
 from __future__ import annotations
 
 import argparse

--- a/duecredit/cmdline/common_args.py
+++ b/duecredit/cmdline/common_args.py
@@ -6,8 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""
-"""
+""" """
 
 __docformat__ = "restructuredtext"
 

--- a/duecredit/cmdline/helpers.py
+++ b/duecredit/cmdline/helpers.py
@@ -6,8 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""
-"""
+""" """
 from __future__ import annotations
 
 __docformat__ = "restructuredtext"

--- a/duecredit/cmdline/main.py
+++ b/duecredit/cmdline/main.py
@@ -7,8 +7,7 @@
 #   under MIT license
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""
-"""
+""" """
 from __future__ import annotations
 
 __docformat__ = "restructuredtext"

--- a/duecredit/collector.py
+++ b/duecredit/collector.py
@@ -419,9 +419,7 @@ class DueCreditCollector:
             # TODO: might make use of inspect.getmro
             # see e.g.
             # http://stackoverflow.com/questions/961048/get-class-that-defined-method
-            lgr.debug(
-                f"Decorating func {func.__name__} within module {modname}"
-            )
+            lgr.debug(f"Decorating func {func.__name__} within module {modname}")
             # TODO: unittest for all the __version__ madness
 
             # TODO: check if we better use wrapt module which provides superior "correctness"

--- a/duecredit/dueswitch.py
+++ b/duecredit/dueswitch.py
@@ -6,8 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Provides an adapter to switch between two (active, inactive) collectors
-"""
+"""Provides an adapter to switch between two (active, inactive) collectors"""
 from __future__ import annotations
 
 import atexit

--- a/duecredit/injections/__init__.py
+++ b/duecredit/injections/__init__.py
@@ -6,8 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Facility to automagically decorate with references other modules
-"""
+"""Facility to automagically decorate with references other modules"""
 
 __docformat__ = "restructuredtext"
 

--- a/duecredit/injections/injector.py
+++ b/duecredit/injections/injector.py
@@ -6,8 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Importer which would also call decoration on a module upon import
-"""
+"""Importer which would also call decoration on a module upon import"""
 from __future__ import annotations
 
 __docformat__ = "restructuredtext"
@@ -105,9 +104,9 @@ class DueCreditInjector:
             collector = due
         self._collector = collector
         self._delayed_injections: dict[str, str] = {}
-        self._entry_records: dict[
-            str, dict[str | None, Any]
-        ] = {}  # dict:  modulename: {object: [('entry', cite kwargs)]}
+        self._entry_records: dict[str, dict[str | None, Any]] = (
+            {}
+        )  # dict:  modulename: {object: [('entry', cite kwargs)]}
         self._processed_modules: set[str] = set()
         # We need to process modules only after we are done with all nested imports, otherwise we
         # might be trying to process them too early -- whenever they are not yet linked to their
@@ -240,9 +239,7 @@ class DueCreditInjector:
                 try:
                     parent, obj_name, obj = find_object(mod, obj_path)
                 except (KeyError, AttributeError) as e:
-                    lgr.warning(
-                        f"Could not find {obj_path} in module {mod}: {e}"
-                    )
+                    lgr.warning(f"Could not find {obj_path} in module {mod}: {e}")
                     continue
 
             # there could be multiple per func

--- a/duecredit/injections/mod_biosig.py
+++ b/duecredit/injections/mod_biosig.py
@@ -6,8 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Automatic injection of bibliography entries for biosig module
-"""
+"""Automatic injection of bibliography entries for biosig module"""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/duecredit/injections/mod_nibabel.py
+++ b/duecredit/injections/mod_nibabel.py
@@ -6,8 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Automatic injection of bibliography entries for nibabel module
-"""
+"""Automatic injection of bibliography entries for nibabel module"""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/duecredit/injections/mod_nipy.py
+++ b/duecredit/injections/mod_nipy.py
@@ -6,8 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Automatic injection of bibliography entries for nipy module
-"""
+"""Automatic injection of bibliography entries for nipy module"""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/duecredit/injections/mod_numpy.py
+++ b/duecredit/injections/mod_numpy.py
@@ -6,8 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Automatic injection of bibliography entries for numpy module
-"""
+"""Automatic injection of bibliography entries for numpy module"""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/duecredit/injections/mod_pandas.py
+++ b/duecredit/injections/mod_pandas.py
@@ -6,8 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Automatic injection of bibliography entries for pandas module
-"""
+"""Automatic injection of bibliography entries for pandas module"""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/duecredit/injections/mod_scipy.py
+++ b/duecredit/injections/mod_scipy.py
@@ -6,8 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Automatic injection of bibliography entries for scipy module
-"""
+"""Automatic injection of bibliography entries for scipy module"""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/duecredit/injections/mod_sklearn.py
+++ b/duecredit/injections/mod_sklearn.py
@@ -6,8 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Automatic injection of bibliography entries for numpy module
-"""
+"""Automatic injection of bibliography entries for numpy module"""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/duecredit/stub.py
+++ b/duecredit/stub.py
@@ -67,9 +67,7 @@ except Exception as e:
     if not isinstance(e, ImportError):
         import logging
 
-        logging.getLogger("duecredit").error(
-            f"Failed to import duecredit due to {e}"
-        )
+        logging.getLogger("duecredit").error(f"Failed to import duecredit due to {e}")
     # Initiate due stub
     due = InactiveDueCreditCollector()  # type: ignore
     BibTeX = Doi = Url = Text = _donothing_func  # type: ignore

--- a/duecredit/tests/mod/submod.py
+++ b/duecredit/tests/mod/submod.py
@@ -1,4 +1,5 @@
 """Some test submodule"""
+
 from typing import Any
 
 

--- a/duecredit/tests/test_api.py
+++ b/duecredit/tests/test_api.py
@@ -112,13 +112,11 @@ def test_api(collector_class) -> None:
 
 
 @overload
-def run_python_command(cmd: str):
-    ...
+def run_python_command(cmd: str): ...
 
 
 @overload
-def run_python_command(cmd: None, script: str):
-    ...
+def run_python_command(cmd: None, script: str): ...
 
 
 def run_python_command(cmd: str | None = None, script: str | None = None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.ruff.lint]
+extend-select = [
+    "B",
+    "A",
+    "W",
+]
+ignore = [
+    "B904",
+    "E402",  # Module level import not at top of file
+]

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ extend-exclude = .venv,venv-debug,venvs,build,dist,doc,git/ext/
 max-line-length = 120
 unused-arguments-ignore-stub-functions = True
 extend-select = B901,B902,B950
-extend-ignore = A003,E203,E501,U101
+extend-ignore = A003,A005,E203,E501,U101
 
 [isort]
 atomic = True


### PR DESCRIPTION
This pull request fixes #231.

Requires #232 to be merged first, then rebase.

### Changes

I'd like to switch from `setup.cfg` to `pyrproject.toml` later on, so maintain ruff configuration in `pyproject.toml`.

- [ ] I ran tests locally and they passed
- [ ] If you would like to list yourself as a DueCredit contributor and your name is not mentioned please modify .zenodo.json file.
