### PR TITLE
isort → ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,11 +14,6 @@ repos:
     hooks:
       - id: black
 
-  - repo: https://github.com/PyCQA/isort
-    rev: 6.0.1
-    hooks:
-      - id: isort
-
   - repo: https://github.com/PyCQA/flake8
     rev: 7.2.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,13 +51,21 @@ duecredit = "duecredit.cmdline.main:main"
 [tool.setuptools_scm]
 version_file = "duecredit/_version.py"
 
+[tool.ruff]
+line-length = 120
+
 [tool.ruff.lint]
 extend-select = [
     "B",
     "A",
+    "I",
     "W",
 ]
 ignore = [
     "B904",
     "E402",  # Module level import not at top of file
 ]
+
+[tool.ruff.lint.isort]
+force-sort-within-sections = true
+relative-imports-order = "closest-to-furthest"

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,11 @@ deps =
 commands =
     mypy --ignore-missing-imports {posargs} duecredit/
 
+[testenv:pre-commit]
+deps =
+    pre-commit
+commands = pre-commit run --all-files --show-diff-on-failure
+
 [flake8]
 doctests = True
 extend-exclude = .venv,venv-debug,venvs,build,dist,doc,git/ext/

--- a/tox.ini
+++ b/tox.ini
@@ -31,16 +31,6 @@ unused-arguments-ignore-stub-functions = True
 extend-select = B901,B902,B950
 extend-ignore = A003,A005,E203,E501,U101
 
-[isort]
-atomic = True
-force_sort_within_sections = True
-honor_noqa = True
-lines_between_sections = 1
-profile = black
-reverse_relative = True
-sort_relative_in_force_sorted_sections = True
-known_first_party = duecredit
-
 [pytest]
 addopts =
     --cov=duecredit


### PR DESCRIPTION
This pull request fixes https://github.com/duecredit/duecredit/pull/234#issuecomment-2766818431.

### Changes

Replace `isort` with `ruff check` and the isort (`I`) ruleset.

The pre-commit/tox.ini stuff is inspired by:
https://docs.releng.linuxfoundation.org/en/latest/best-practices.html#set-up-pre-commit-for-a-project

- [ ] I ran tests locally and they passed
- [ ] If you would like to list yourself as a DueCredit contributor and your name is not mentioned please modify .zenodo.json file.
