### PR TITLE
Require citeproc-py 0.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "citeproc-py>=0.4",
+    "citeproc-py>=0.5",
     "looseversion",
     "packaging",
     "requests",


### PR DESCRIPTION
Should fix https://github.com/citeproc-py/citeproc-py/issues/78 which in turn should fix #125 and #134.

### Changes

- [ ] I ran tests locally and they passed
- [ ] If you would like to list yourself as a DueCredit contributor and your name is not mentioned please modify .zenodo.json file.
