### PR TITLE
Bf bibtex month workaround

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -60,6 +60,11 @@
       "affiliation": "Dartmouth College: Hanover, NH, United States",
       "name": "Macdonald, Austin",
       "orcid": "0000-0002-8124-807X"
+    },
+    {
+      "affiliation": "The Pennsylvania State University",
+      "name": "Amaral, Ricardo",
+      "orcid": "0000-0003-1070-9964"
     }
   ],
   "grants": [

--- a/duecredit/io.py
+++ b/duecredit/io.py
@@ -286,6 +286,14 @@ def condition_bibtex(bibtex: str) -> bytes:
     # remove opening letter, e.g. 'S123' -> '123'
     # related issue: https://github.com/brechtm/citeproc-py/issues/74
     bibtex = re.sub(r'(pages\s*=\s*["{])([a-zA-Z])', r"\g<1>", bibtex)
+    # workaround for non-standard month macros returned by doi.org publishers
+    # e.g. 'june', 'sept', 'january' — truncate unquoted bare-word month values
+    # longer than 3 chars to the standard 3-letter BibTeX macro (jan..dec)
+    bibtex = re.sub(
+        r"(month\s*=\s*)([a-zA-Z]{4,})",
+        lambda m: m.group(1) + m.group(2)[:3].lower(),
+        bibtex,
+    )
     return bibtex.encode("utf-8")
 
 

--- a/duecredit/tests/test_io.py
+++ b/duecredit/tests/test_io.py
@@ -28,6 +28,7 @@ from ..io import (
     PickleOutput,
     TextOutput,
     _is_contained,
+    condition_bibtex,
     format_bibtex,
     get_text_rendering,
     import_doi,
@@ -93,6 +94,44 @@ def test_pickleoutput(tmpdir) -> None:
         # TODO: implement comparison of citations
         assert collector._entries.keys() == collector_loaded._entries.keys()
         os.unlink(tempfile)
+
+
+@pytest.mark.parametrize(
+    "month_in, month_out",
+    [
+        # long-form month names
+        ("january", "jan"),
+        ("february", "feb"),
+        ("march", "mar"),
+        ("april", "apr"),
+        ("june", "jun"),
+        ("july", "jul"),
+        ("august", "aug"),
+        ("september", "sep"),
+        ("october", "oct"),
+        ("november", "nov"),
+        ("december", "dec"),
+        # non-standard abbreviations
+        ("sept", "sep"),
+        # standard 3-letter macros must be left untouched
+        ("jan", "jan"),
+        ("sep", "sep"),
+    ],
+)
+def test_condition_bibtex_month_macros(month_in: str, month_out: str) -> None:
+    """condition_bibtex normalises non-standard month macros to 3-letter form."""
+    bibtex = f"@article{{key, title={{T}}, year={{2024}}, month = {month_in},}}"
+    result = condition_bibtex(bibtex).decode("utf-8")
+    assert f"month = {month_out}" in result, (
+        f"Expected 'month = {month_out}' in conditioned bibtex, got: {result!r}"
+    )
+
+
+def test_condition_bibtex_quoted_month_untouched() -> None:
+    """condition_bibtex must not alter already-quoted month values."""
+    bibtex = "@article{key, title={T}, year={2024}, month = {June},}"
+    result = condition_bibtex(bibtex).decode("utf-8")
+    assert "month = {June}" in result
 
 
 def test_output() -> None:

--- a/duecredit/tests/test_io.py
+++ b/duecredit/tests/test_io.py
@@ -134,6 +134,37 @@ def test_condition_bibtex_quoted_month_untouched() -> None:
     assert "month = {June}" in result
 
 
+@pytest.mark.parametrize(
+    "doi, month",
+    [
+        ("10.1016/j.commatsci.2022.111254", "june"),
+        ("10.1038/s42256-023-00716-3", "sept"),
+        ("10.1103/PhysRevX.14.021036", "june"),
+    ],
+)
+def test_doi_month_macro_regression(
+    monkeypatch: MonkeyPatch, doi: str, month: str
+) -> None:
+    """Regression test: DOI rendering must not error on bare non-standard month macros."""
+
+    def _import_doi(_doi: str, sleep: float = 0.5, retries: int = 10) -> str:
+        assert _doi == doi
+        return (
+            "@article{MonthMacroRegression,"
+            "title={Month Macro Regression},"
+            "author={Doe, Jane},"
+            f"month = {month},"
+            "year={2024},"
+            "journal={Journal of Tests}"
+            "}"
+        )
+
+    monkeypatch.setattr(duecredit.io, "import_doi", _import_doi)
+
+    rendered = get_text_rendering(Doi(doi))
+    assert "ERRORED:" not in rendered, f"unexpected rendering error: {rendered}"
+
+
 def test_output() -> None:
     entry = BibTeX(_sample_bibtex)
     entry2 = BibTeX(_sample_bibtex2)


### PR DESCRIPTION
<!-- Specify which issue this PR fixes -->
This pull request fixes #264

<!-- Below provide a summary of what, why, and how  for the changes in this PR -->
Some DOI-resolved entries return BibTeX with bare-word month values longer than the standard 3-letter macros (e.g. `month = june`, `month = sept`). citeproc-py has no entry for these in its string table and raises a `KeyError` → "ERRORED: 'june'" in the rendered output.

Truncate any unquoted month value longer than 3 characters to its first 3 letters (lowercased), mapping it to the standard BibTeX macro. Already-quoted values ({June}, "June") and standard 3-letter macros are left untouched.  

### Changes

- [X] I ran tests locally and they passed
- [X] If you would like to list yourself as a DueCredit contributor and your name is not mentioned please modify .zenodo.json file.
