### PR TITLE
update `condition_bibtex` to convert both @data/@software to @misc + …

### DIFF
--- a/duecredit/io.py
+++ b/duecredit/io.py
@@ -272,10 +272,10 @@ def condition_bibtex(bibtex: str) -> bytes:
     Primarily a set of workarounds for either non-standard BibTeX entries
     or citeproc bugs
     """
-    # XXX: workaround atm to fix zenodo bibtexs, convert @data to @misc
+    # XXX: workaround atm to fix zenodo/github bibtexs, convert @data/@software to @misc
     # and also ; into and
-    if bibtex.startswith("@data"):
-        bibtex = bibtex.replace("@data", "@misc", 1)
+    bibtex, n_subs = re.subn(r"^(\s*)@(data|software)\b", r"\1@misc", bibtex, count=1)
+    if n_subs:
         bibtex = bibtex.replace(";", " and")
     bibtex = bibtex.replace("\u2013", "--") + "\n"
     # workaround for citeproc 0.3.0 failing to parse a single page pages field

--- a/duecredit/tests/test_io.py
+++ b/duecredit/tests/test_io.py
@@ -685,6 +685,25 @@ def test_format_bibtex_zenodo_doi() -> None:
     )
 
 
+def test_format_bibtex_github_software() -> None:
+    """
+    test that we can correctly parse bibtex software entries obtained from GitHub citation exporter (CITATION.cff)
+    """
+    bibtex_software = """
+    @software{The_pandas_development_team_pandas-dev_pandas_Pandas,
+    author = {{The pandas development team}},
+    doi = {10.5281/zenodo.3509134},
+    license = {BSD-3-Clause},
+    title = {{pandas-dev/pandas: Pandas}},
+    url = {https://github.com/pandas-dev/pandas}
+    }
+    """
+    assert (
+        format_bibtex(BibTeX(bibtex_software))
+        == "The pandas development team, pandas-dev/pandas: Pandas."
+    )
+
+
 def test_format_bibtex_with_utf_characters() -> None:
     """
     test that we can correctly parse bibtex entry if it contains utf-8 characters


### PR DESCRIPTION
<!-- Specify which issue this PR fixes -->
This pull request fixes #266

<!-- Below provide a summary of what, why, and how  for the changes in this PR -->

### Changes
- Replace non-standard `@data` and `@software` BibTeX entry types with `@misc` in `condition_bibtex()` using a single regex substitution, so citeproc-py can process them correctly.
- Add tests to cover @software BibTeX entries.

- [X] I ran tests locally and they passed
